### PR TITLE
Initial implementation for source collections.

### DIFF
--- a/src/DynamicDataVNext/Distinct/ChangeTrackingSet.cs
+++ b/src/DynamicDataVNext/Distinct/ChangeTrackingSet.cs
@@ -1,0 +1,495 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// A collection of distinct items, which tracks and allows for capturing of changes made to it, as they occur.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public sealed class ChangeTrackingSet<T>
+    : IExtendedSet<T>,
+        IReadOnlySet<T>
+{
+    private readonly DistinctChangeSet.Builder<T>   _changeCollector;
+    private readonly IEqualityComparer<T>           _comparer;
+
+    private bool        _isChangeCollectionEnabled;
+    private bool        _isDirty;
+    private HashSet<T>  _items;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="ChangeTrackingSet{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="comparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public ChangeTrackingSet(
+        int?                    capacity = null,
+        IEqualityComparer<T>?   comparer = null)
+    {
+        _comparer = comparer ?? EqualityComparer<T>.Default;
+
+        _items = (capacity is int givenCapacity)
+            ? new(
+                capacity: givenCapacity,
+                comparer: _comparer)
+            : new(
+                comparer: _comparer);
+
+        _changeCollector = new();
+        _isChangeCollectionEnabled = true;
+    }
+
+    /// <summary>
+    /// The comparer to be used for matching items against each other.
+    /// </summary>
+    public IEqualityComparer<T> Comparer
+        => _items.Comparer;
+
+    /// <inheritdoc/>
+    public int Count
+        => _items.Count;
+
+    /// <summary>
+    /// A flag indicating whether the collection should actually collect changes, to be retrieved by calls to <see cref="CaptureChangesAndClean"/>.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note that any changes previously collected, but not captured, when this property is set to <see langword="false"/> will be discarded. Otherwise, it would be possible for <see cref="CaptureChangesAndClean"/> to generate a corrupt changes, when next called, after setting this property back to <see langword="true"/>.
+    /// </remarks>
+    public bool IsChangeCollectionEnabled
+    { 
+        get => _isChangeCollectionEnabled;
+        set
+        {
+            if ((value is false) && (_changeCollector.Count is not 0))
+                _changeCollector.Clear();
+
+            _isChangeCollectionEnabled = value;
+        }
+    }
+
+    /// <summary>
+    /// A flag indicating whether changes have been made to the collection since its creation, or since the last call to `<see cref="CaptureChangesAndClean"/>.
+    /// </summary>
+    public bool IsDirty
+        => _isDirty;
+
+    /// <summary>
+    /// Captures any previously-collected changes made to the collection, and resets the collection to a "clean" state (I.E. sets <see cref="IsDirty"/> to <see langword="false"/>).
+    /// </summary>
+    /// <returns>A <see cref="DistinctChangeSet{T}"/> containing all changes made to the collection since its construction, the last call to <see cref="CaptureChangesAndClean"/>, or since <see cref="IsChangeCollectionEnabled"/> was last changed to <see langword="true"/>.</returns>
+    /// <remarks>
+    /// Note that this method will always return an empty changeset, when <see cref="IsChangeCollectionEnabled"/> is <see langword="false"/>.
+    /// </remarks>
+    public DistinctChangeSet<T> CaptureChangesAndClean()
+    {
+        _isDirty = false;
+        return _changeCollector.BuildAndClear();
+    }
+
+    /// <inheritdoc/>
+    public bool Add(T item)
+    {
+        var result = _items.Add(item);
+
+        if (result && _isChangeCollectionEnabled)
+            _changeCollector.AddChange(DistinctChange.Addition(item));
+
+        _isDirty |= result;
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (_items.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            foreach (var item in _items)
+                _changeCollector.AddChange(DistinctChange.Removal(item));
+
+            _changeCollector.OnSourceCleared();
+        }
+
+        _items.Clear();
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+        => _items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            T[] array,
+            int arrayIndex)
+        => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc cref="HashSet{T}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _items.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public void ExceptWith(IEnumerable<T> other)
+    {
+        if (_items.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            if(other.TryGetNonEnumeratedCount(out var otherCount))
+            {
+                if (otherCount is 0)
+                    return;
+
+                _changeCollector.EnsureCapacity(Math.Min(otherCount, _items.Count));
+            }
+
+            foreach (var item in other)
+                if (_items.Remove(item))
+                {
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                    _isDirty = true;
+                }
+
+            if (_items.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+        else
+        {
+            var oldCount = _items.Count;
+
+            _items.ExceptWith(other);
+
+            _isDirty |= _items.Count != oldCount;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void ExceptWith(ReadOnlySpan<T> other)
+    {
+        if ((other.Length is 0) || (_items.Count is 0))
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.EnsureCapacity(Math.Min(other.Length, _items.Count));
+
+            foreach (var item in other)
+                if (_items.Remove(item))
+                {
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                    _isDirty = true;
+                }
+
+            if (_items.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+        else
+        {
+            foreach (var item in other)
+                _isDirty |= _items.Remove(item);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void IntersectWith(IEnumerable<T> other)
+    {
+        if (_items.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            if(other.TryGetNonEnumeratedCount(out var otherCount))
+                _changeCollector.EnsureCapacity(Math.Min(0, _items.Count - otherCount));
+
+            var newItems = new HashSet<T>(capacity: Math.Min(otherCount, _items.Count));
+            var hasChanges = false;
+            foreach (var item in other)
+            {
+                if (_items.Remove(item))
+                    newItems.Add(item);
+                else
+                {
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                    hasChanges = true;
+                }
+            }
+
+            if (hasChanges)
+            {
+                _items = newItems;
+                _isDirty = true;
+
+                if (_items.Count is 0)
+                    _changeCollector.OnSourceCleared();
+            }
+        }
+        else
+        {
+            var oldCount = _items.Count;
+            
+            _items.IntersectWith(other);
+
+            _isDirty = _items.Count != oldCount;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void IntersectWith(ReadOnlySpan<T> other)
+    {
+        if (_items.Count is 0)
+            return;
+
+        var newItems = new HashSet<T>(capacity: Math.Min(other.Length, _items.Count));
+        var hasChanges = false;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.EnsureCapacity(Math.Min(0, _items.Count - other.Length));
+
+            foreach (var item in other)
+            {
+                if (_items.Remove(item))
+                    newItems.Add(item);
+                else
+                {
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                    hasChanges = true;
+                }
+            }
+        }
+        else
+        {
+            foreach (var item in other)
+            {
+                if (_items.Remove(item))
+                    newItems.Add(item);
+                else
+                    hasChanges = true;
+            }
+        }
+
+        if (hasChanges)
+        {
+            _items = newItems;
+            _isDirty = true;
+
+            if (_isChangeCollectionEnabled && (_items.Count is 0))
+                _changeCollector.OnSourceCleared();
+        }
+    }
+
+    /// <inheritdoc/>
+    public HashSet<T>.Enumerator GetEnumerator()
+        => _items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool IsProperSubsetOf(IEnumerable<T> other)
+        => _items.IsProperSubsetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsProperSupersetOf(IEnumerable<T> other)
+        => _items.IsProperSupersetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsSubsetOf(IEnumerable<T> other)
+        => _items.IsSubsetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsSupersetOf(IEnumerable<T> other)
+        => _items.IsSupersetOf(other);
+
+    /// <inheritdoc/>
+    public bool Overlaps(IEnumerable<T> other)
+        => _items.Overlaps(other);
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        var result = _items.Remove(item);
+
+        if (result && _isChangeCollectionEnabled)
+            _changeCollector.AddChange(DistinctChange.Removal(item));
+
+        _isDirty |= result;
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<T> items)
+    {
+        Clear();
+        UnionWith(items);
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<T> items)
+    {
+        Clear();
+        UnionWith(items);
+    }
+
+    /// <inheritdoc/>
+    public bool SetEquals(IEnumerable<T> other)
+        => _items.SetEquals(other);
+
+    /// <inheritdoc/>
+    public void SymmetricExceptWith(IEnumerable<T> other)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            if(other.TryGetNonEnumeratedCount(out var otherCount))
+            { 
+                if (otherCount is 0)
+                    return;
+
+                _items.EnsureCapacity(_items.Count + otherCount);
+                _changeCollector.EnsureCapacity(_items.Count + otherCount);
+            }
+
+            foreach (var item in other)
+            {
+                if (_items.Add(item))
+                    _changeCollector.AddChange(DistinctChange.Addition(item));
+                else
+                {
+                    _items.Remove(item);
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                }
+
+                _isDirty = true;
+            }
+
+            if (_items.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+        else
+        {
+            foreach (var item in other)
+            {
+                if (!_items.Add(item))
+                    _items.Remove(item);
+
+                _isDirty = true;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void SymmetricExceptWith(ReadOnlySpan<T> other)
+    {
+        if (other.Length is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _items.EnsureCapacity(_items.Count + other.Length);
+            _changeCollector.EnsureCapacity(_items.Count + other.Length);
+
+            foreach (var item in other)
+            {
+                if (_items.Add(item))
+                    _changeCollector.AddChange(DistinctChange.Addition(item));
+                else
+                {
+                    _items.Remove(item);
+                    _changeCollector.AddChange(DistinctChange.Removal(item));
+                }
+
+                _isDirty = true;
+            }
+
+            if (_items.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+        else
+        {
+            foreach (var item in other)
+            {
+                if (!_items.Add(item))
+                    _items.Remove(item);
+
+                _isDirty = true;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void UnionWith(IEnumerable<T> other)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            if (other.TryGetNonEnumeratedCount(out var otherCount))
+            {
+                if (otherCount is 0)
+                    return;
+
+                _items.EnsureCapacity(_items.Count + otherCount);
+
+                _changeCollector.EnsureCapacity(otherCount);
+            }
+
+            foreach(var item in other)
+                if (_items.Add(item))
+                {
+                    _changeCollector.AddChange(DistinctChange.Addition(item));
+                    _isDirty = true;
+                }
+        }
+        else
+        {
+            var oldCount = _items.Count;
+
+            _items.UnionWith(other);
+
+            _isDirty |= oldCount != _items.Count;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void UnionWith(ReadOnlySpan<T> other)
+    {
+        if (other.Length is 0)
+            return;
+
+        _items.EnsureCapacity(_items.Count + other.Length);
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.EnsureCapacity(other.Length);
+
+            foreach(var item in other)
+                if (_items.Add(item))
+                {
+                    _changeCollector.AddChange(DistinctChange.Addition(item));
+                    _isDirty = true;
+                }
+        }
+        else
+        {
+            foreach(var item in other)
+                _isDirty |= _items.Add(item);
+        }
+    }
+
+    bool ICollection<T>.IsReadOnly
+        => false;
+
+    void ICollection<T>.Add(T item)
+        => Add(item);
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        => _items.GetEnumerator();
+}

--- a/src/DynamicDataVNext/Distinct/DistinctChangeSet.cs
+++ b/src/DynamicDataVNext/Distinct/DistinctChangeSet.cs
@@ -30,7 +30,7 @@ public static partial class DistinctChangeSet
     /// <typeparam name="T">The type of the items being added.</typeparam>
     /// <param name="items">The items being added.</param>
     /// <returns>A <see cref="DistinctChangeSet{T}"/> describing the addition of the given items.</returns>
-    public static DistinctChangeSet<T> Addition<T>(IEnumerable<T> items)
+    public static DistinctChangeSet<T> BulkAddition<T>(IEnumerable<T> items)
     {
         if (!items.TryGetNonEnumeratedCount(out var itemsCount))
             itemsCount = 0;
@@ -47,13 +47,51 @@ public static partial class DistinctChangeSet
         };
     }
 
-    /// <inheritdoc cref="Addition{T}(IEnumerable{T})"/>
-    public static DistinctChangeSet<T> Addition<T>(ReadOnlySpan<T> items)
+    /// <inheritdoc cref="BulkAddition{T}(IEnumerable{T})"/>
+    public static DistinctChangeSet<T> BulkAddition<T>(ReadOnlySpan<T> items)
     {
         var changes = ImmutableArray.CreateBuilder<DistinctChange<T>>(initialCapacity: items.Length);
 
         foreach(var item in items)
             changes.Add(DistinctChange.Addition(item));
+
+        return new()
+        {
+            Changes = changes.MoveToImmutable(),
+            Type    = ChangeSetType.Update
+        };
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="DistinctChangeSet{T}"/> representing the removal of a range of items.
+    /// </summary>
+    /// <typeparam name="T">The type of the items being removed.</typeparam>
+    /// <param name="items">The items being removed.</param>
+    /// <returns>A <see cref="DistinctChangeSet{T}"/> describing the removal of the given items.</returns>
+    public static DistinctChangeSet<T> BulkRemoval<T>(IEnumerable<T> items)
+    {
+        if (!items.TryGetNonEnumeratedCount(out var itemsCount))
+            itemsCount = 0;
+
+        var changes = ImmutableArray.CreateBuilder<DistinctChange<T>>(initialCapacity: itemsCount);
+
+        foreach(var item in items)
+            changes.Add(DistinctChange.Removal(item));
+
+        return new()
+        {
+            Changes = changes.MoveToOrCreateImmutable(),
+            Type    = ChangeSetType.Update
+        };
+    }
+
+    /// <inheritdoc cref="BulkRemoval{T}(IEnumerable{T})"/>
+    public static DistinctChangeSet<T> BulkRemoval<T>(ReadOnlySpan<T> items)
+    {
+        var changes = ImmutableArray.CreateBuilder<DistinctChange<T>>(initialCapacity: items.Length);
+
+        foreach(var item in items)
+            changes.Add(DistinctChange.Removal(item));
 
         return new()
         {
@@ -112,44 +150,6 @@ public static partial class DistinctChangeSet
             Changes = ImmutableArray.Create(DistinctChange.Removal(item)),
             Type    = ChangeSetType.Update
         };
-
-    /// <summary>
-    /// Creates a new <see cref="DistinctChangeSet{T}"/> representing the removal of a range of items.
-    /// </summary>
-    /// <typeparam name="T">The type of the items being removed.</typeparam>
-    /// <param name="items">The items being removed.</param>
-    /// <returns>A <see cref="DistinctChangeSet{T}"/> describing the removal of the given items.</returns>
-    public static DistinctChangeSet<T> Removal<T>(IEnumerable<T> items)
-    {
-        if (!items.TryGetNonEnumeratedCount(out var itemsCount))
-            itemsCount = 0;
-
-        var changes = ImmutableArray.CreateBuilder<DistinctChange<T>>(initialCapacity: itemsCount);
-
-        foreach(var item in items)
-            changes.Add(DistinctChange.Removal(item));
-
-        return new()
-        {
-            Changes = changes.MoveToOrCreateImmutable(),
-            Type    = ChangeSetType.Update
-        };
-    }
-
-    /// <inheritdoc cref="Removal{T}(IEnumerable{T})"/>
-    public static DistinctChangeSet<T> Removal<T>(ReadOnlySpan<T> items)
-    {
-        var changes = ImmutableArray.CreateBuilder<DistinctChange<T>>(initialCapacity: items.Length);
-
-        foreach(var item in items)
-            changes.Add(DistinctChange.Removal(item));
-
-        return new()
-        {
-            Changes = changes.MoveToImmutable(),
-            Type    = ChangeSetType.Update
-        };
-    }
 
     /// <summary>
     /// Creates a new <see cref="DistinctChangeSet{T}"/> representing the resetting of items in a collection of distinct items.

--- a/src/DynamicDataVNext/Distinct/IExtendedSet.cs
+++ b/src/DynamicDataVNext/Distinct/IExtendedSet.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// Describes an extended version of <see cref="ISet{T}"/>, supporting range operations.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public interface IExtendedSet<T>
+    : ISet<T>
+{
+    /// <inheritdoc cref="ISet{T}.ExceptWith(IEnumerable{T})"/>.
+    void ExceptWith(ReadOnlySpan<T> other);
+
+    /// <inheritdoc cref="ISet{T}.IntersectWith(IEnumerable{T})"/>.
+    void IntersectWith(ReadOnlySpan<T> other);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items with which to populate the collection.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void Reset(IEnumerable<T> items);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items with which to populate the collection.</param>
+    void Reset(ReadOnlySpan<T> items);
+
+    /// <inheritdoc cref="ISet{T}.SymmetricExceptWith(IEnumerable{T})"/>.
+    void SymmetricExceptWith(ReadOnlySpan<T> other);
+
+    /// <inheritdoc cref="ISet{T}.UnionWith(IEnumerable{T})"/>.
+    void UnionWith(ReadOnlySpan<T> other);
+}

--- a/src/DynamicDataVNext/Distinct/ISubjectSet.cs
+++ b/src/DynamicDataVNext/Distinct/ISubjectSet.cs
@@ -9,20 +9,13 @@ namespace DynamicDataVNext;
 /// </summary>
 /// <typeparam name="T">The type of the items in the collection.</typeparam>
 public interface ISubjectSet<T>
-    : ISet<T>,
+    : IExtendedSet<T>,
         IObservable<DistinctChangeSet<T>>
 {
     /// <summary>
     /// An event that occurs after any mutation of the collection occurs.
     /// </summary>
     IObservable<Unit> CollectionChanged { get; }
-
-    /// <summary>
-    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
-    /// </summary>
-    /// <param name="items">The set of items with which to populate the collection.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
-    void Reset(IEnumerable<T> items);
 
     /// <summary>
     /// Temporarily suspends the publication of notifications by the collection, until the returned object is disposed, at which point all mutations made during the suspension will (if any) will be published as one notification.

--- a/src/DynamicDataVNext/Distinct/SubjectSet.cs
+++ b/src/DynamicDataVNext/Distinct/SubjectSet.cs
@@ -1,0 +1,299 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// The basic implementation of <see cref="ISubjectSet{T}"/>, providing simple collection and change notification functionality, with no concurrency or thread-safety.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public sealed class SubjectSet<T>
+        : ISubjectSet<T>,
+            IObservableSet<T>,
+            IDisposable
+    where T : notnull
+{
+    private readonly Subject<DistinctChangeSet<T>>  _changeStream;
+    private readonly Subject<Unit>                  _collectionChanged;
+    private readonly Subject<Unit>                  _notificationsResumed;
+    private readonly Action                         _onChangeStreamFinalized;
+    private readonly ChangeTrackingSet<T>           _items;
+
+    private int _notificationSuspensionCount;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SubjectSet{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="comparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public SubjectSet(
+        int?                    capacity    = null,
+        IEqualityComparer<T>?   comparer    = null)
+    {
+        _collectionChanged      = new();
+        _changeStream           = new();
+        _notificationsResumed   = new();
+        _items                  = new(
+            capacity:   capacity,
+            comparer:   comparer);
+
+        _onChangeStreamFinalized = () => _items.IsChangeCollectionEnabled = _changeStream.HasObservers;
+    }
+
+    /// <inheritdoc/>
+    public IObservable<Unit> CollectionChanged
+        => _collectionChanged;
+
+    /// <inheritdoc cref="ChangeTrackingSet{T}.Comparer"/>
+    public IEqualityComparer<T> Comparer
+        => _items.Comparer;
+
+    /// <inheritdoc/>
+    public int Count
+        => _items.Count;
+
+    /// <inheritdoc/>
+    public bool Add(T item)
+    {
+        var result = _items.Add(item);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        _items.Clear();
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+        => _items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+        => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _changeStream           .OnCompleted();
+        _collectionChanged      .OnCompleted();
+        _notificationsResumed   .OnCompleted();
+
+        _changeStream           .Dispose();
+        _collectionChanged      .Dispose();
+        _notificationsResumed   .Dispose();
+    }
+
+    /// <inheritdoc cref="ChangeTrackingSet{T}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _items.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public void ExceptWith(ReadOnlySpan<T> other)
+    {
+        _items.ExceptWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void ExceptWith(IEnumerable<T> other)
+    {
+        _items.ExceptWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public HashSet<T>.Enumerator GetEnumerator()
+        => _items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public void IntersectWith(ReadOnlySpan<T> other)
+    {
+        _items.IntersectWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void IntersectWith(IEnumerable<T> other)
+    {
+        _items.IntersectWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public bool IsProperSubsetOf(IEnumerable<T> other)
+        => _items.IsProperSubsetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsProperSupersetOf(IEnumerable<T> other)
+        => _items.IsProperSupersetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsSubsetOf(IEnumerable<T> other)
+        => _items.IsSubsetOf(other);
+
+    /// <inheritdoc/>
+    public bool IsSupersetOf(IEnumerable<T> other)
+        => _items.IsSupersetOf(other);
+
+    /// <inheritdoc/>
+    public bool Overlaps(IEnumerable<T> other)
+        => _items.Overlaps(other);
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        var result = _items.Remove(item);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<T> items)
+    {
+        _items.Reset(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<T> items)
+    {
+        _items.Reset(items);
+
+        PublishPendingNotifications();
+    }
+    /// <inheritdoc/>
+    public bool SetEquals(IEnumerable<T> other)
+        => _items.SetEquals(other);
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<DistinctChangeSet<T>> observer)
+    {
+        _items.IsChangeCollectionEnabled = true;
+        
+        return ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<Unit>()
+                : _notificationsResumed
+                    .Take(1))
+            .Select(_ => _changeStream
+                .Finally(_onChangeStreamFinalized)
+                .Prepend(DistinctChangeSet.BulkAddition(_items)))
+            .Switch()
+            .Subscribe(observer);
+    }
+
+    /// <inheritdoc/>
+    public NotificationSuspension SuspendNotifications()
+    {
+        ++_notificationSuspensionCount;
+        return new(this);
+    }
+
+    /// <inheritdoc/>
+    public void SymmetricExceptWith(ReadOnlySpan<T> other)
+    {
+        _items.SymmetricExceptWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void SymmetricExceptWith(IEnumerable<T> other)
+    {
+        _items.SymmetricExceptWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void UnionWith(ReadOnlySpan<T> other)
+    {
+        _items.UnionWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void UnionWith(IEnumerable<T> other)
+    {
+        _items.UnionWith(other);
+
+        PublishPendingNotifications();
+    }
+
+    bool ICollection<T>.IsReadOnly
+        => false;
+
+    void ICollection<T>.Add(T item)
+        => Add(item);
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IDisposable ISubjectSet<T>.SuspendNotifications()
+        => SuspendNotifications();
+
+    private void OnNotificationSuspensionDisposed()
+    {
+        --_notificationSuspensionCount;
+        if (_notificationSuspensionCount is 0)
+        {
+            PublishPendingNotifications();
+
+            _notificationsResumed.OnNext(Unit.Default);
+        }
+    }
+
+    private void PublishPendingNotifications()
+    {
+        if ((_notificationSuspensionCount is not 0) || !_items.IsDirty)
+            return;
+
+        _collectionChanged.OnNext(Unit.Default);
+
+        _changeStream.OnNext(_items.CaptureChangesAndClean());
+    }
+
+    /// <summary>
+    /// A value that controls suspension of notifications, for a <see cref="SubjectSet{T}"/>. Will trigger notifications to be resumed, when disposed.
+    /// </summary>
+    public struct NotificationSuspension
+        : IDisposable
+    {
+        private SubjectSet<T>? _owner;
+
+        internal NotificationSuspension(SubjectSet<T> owner)
+            => _owner = owner;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_owner is not null)
+            {
+                _owner.OnNotificationSuspensionDisposed();
+                _owner = null;
+            }
+        }
+    }
+}

--- a/src/DynamicDataVNext/Keyed/ChangeTrackingCache.cs
+++ b/src/DynamicDataVNext/Keyed/ChangeTrackingCache.cs
@@ -1,0 +1,367 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net.Http.Headers;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// A collection of distinctly-keyed items, which tracks and allows for capturing of changes made to it, as they occur.
+/// </summary>
+/// <typeparam name="TKey">The type of the key values of items in the collection.</typeparam>
+/// <typeparam name="TItem">The type of the items in the collection.</typeparam>
+public sealed class ChangeTrackingCache<TKey, TItem>
+        : ICache<TKey, TItem>,
+            IReadOnlyCache<TKey, TItem>
+    where TKey : notnull
+{
+    private readonly KeyedChangeSet.Builder<TKey, TItem>    _changeCollector;
+    private readonly IEqualityComparer<TItem>               _itemComparer;
+    private readonly Dictionary<TKey, TItem>                _itemsByKey;
+    private readonly Func<TItem, TKey>                      _keySelector;
+
+    private bool _isChangeCollectionEnabled;
+    private bool _isDirty;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="ChangeTrackingCache{TKey, TItem}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="keyComparer">The comparer to be used for matching keys against each other, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    /// <param name="itemComparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public ChangeTrackingCache(
+        Func<TItem, TKey>           keySelector,
+        int?                        capacity        = null,
+        IEqualityComparer<TKey>?    keyComparer     = null,
+        IEqualityComparer<TItem>?   itemComparer    = null)
+    {
+        _keySelector = keySelector;
+
+        _itemComparer = itemComparer ?? EqualityComparer<TItem>.Default;
+
+        _itemsByKey = (capacity is int givenCapacity)
+            ? new(
+                capacity:   givenCapacity,
+                comparer:   keyComparer)
+            : new(
+                comparer:   keyComparer);
+
+        _changeCollector = new();
+        _isChangeCollectionEnabled = true;
+    }
+
+    /// <inheritdoc/>
+    public TItem this[TKey key]
+        => _itemsByKey[key];
+
+    /// <inheritdoc/>
+    public int Count
+        => _itemsByKey.Count;
+
+    /// <summary>
+    /// A flag indicating whether the collection should actually collect changes, to be retrieved by calls to <see cref="CaptureChangesAndClean"/>.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note that any changes previously collected, but not captured, when this property is set to <see langword="false"/> will be discarded. Otherwise, it would be possible for <see cref="CaptureChangesAndClean"/> to generate a corrupt changes, when next called, after setting this property back to <see langword="true"/>.
+    /// </remarks>
+    public bool IsChangeCollectionEnabled
+    { 
+        get => _isChangeCollectionEnabled;
+        set
+        {
+            if ((value is false) && (_changeCollector.Count is not 0))
+                _changeCollector.Clear();
+
+            _isChangeCollectionEnabled = value;
+        }
+    }
+
+    /// <summary>
+    /// A flag indicating whether changes have been made to the collection since its creation, or since the last call to `<see cref="CaptureChangesAndClean"/>.
+    /// </summary>
+    public bool IsDirty
+        => _isDirty;
+
+    /// <summary>
+    /// The comparer to be used for detecting value changes, within the collection.
+    /// </summary>
+    public IEqualityComparer<TItem> ItemComparer
+        => _itemComparer;
+
+    /// <summary>
+    /// The comparer to be used for matching key values against each other.
+    /// </summary>
+    public IEqualityComparer<TKey> KeyComparer
+        => _itemsByKey.Comparer;
+
+    /// <summary>
+    /// The function used by the collection to identify the key values of items.
+    /// </summary>
+    public Func<TItem, TKey> KeySelector
+        => _keySelector;
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TItem>.KeyCollection Keys
+        => _itemsByKey.Keys;
+
+    /// <inheritdoc/>
+    public void Add(TItem item)
+    {
+        var key = _keySelector.Invoke(item);
+
+        _itemsByKey.Add(key, item);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.AddChange(KeyedChange.Addition(key, item));
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplace(TItem item)
+    {
+        var key = _keySelector.Invoke(item);
+
+        var wasKeyFound = _itemsByKey.TryGetValue(key, out var oldItem);
+
+        if (wasKeyFound && _itemComparer.Equals(oldItem, item))
+            return;
+
+        _itemsByKey[key] = item;
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.AddChange(wasKeyFound
+                ? KeyedChange.Replacement(
+                    key:        key,
+                    oldItem:    oldItem!,
+                    newItem:    item)
+                : KeyedChange.Addition(key, item));
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(IEnumerable<TItem> values)
+    {
+        ArgumentNullException.ThrowIfNull(values, nameof(values));
+
+        if (values.TryGetNonEnumeratedCount(out var valueCount))
+        {
+            _itemsByKey.EnsureCapacity(_itemsByKey.Count + valueCount);
+
+            if (_isChangeCollectionEnabled)
+                _changeCollector.EnsureCapacity(_changeCollector.Count + valueCount);
+        }
+
+        foreach (var value in values)
+            AddOrReplace(value);
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(ReadOnlySpan<TItem> values)
+    {
+        _itemsByKey.EnsureCapacity(_itemsByKey.Count + values.Length);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.EnsureCapacity(_changeCollector.Count + values.Length);
+
+        foreach (var value in values)
+            AddOrReplace(value);
+    }
+
+    /// <summary>
+    /// Captures any previously-collected changes made to the collection, and resets the collection to a "clean" state (I.E. sets <see cref="IsDirty"/> to <see langword="false"/>).
+    /// </summary>
+    /// <returns>A <see cref="KeyedChangeSet{TKey, TItem}"/> containing all changes made to the collection since its construction, the last call to <see cref="CaptureChangesAndClean"/>, or since <see cref="IsChangeCollectionEnabled"/> was last changed to <see langword="true"/>.</returns>
+    /// <remarks>
+    /// Note that this method will always return an empty changeset, when <see cref="IsChangeCollectionEnabled"/> is <see langword="false"/>.
+    /// </remarks>
+    public KeyedChangeSet<TKey, TItem> CaptureChangesAndClean()
+    {
+        _isDirty = false;
+        return _changeCollector.BuildAndClear();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (_itemsByKey.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.EnsureCapacity(_itemsByKey.Count);
+
+            foreach (var item in _itemsByKey)
+                _changeCollector.AddChange(KeyedChange.Removal(item.Key, item.Value));
+
+            _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(TItem item)
+        => _itemsByKey.TryGetValue(_keySelector.Invoke(item), out var existingItem)
+            && _itemComparer.Equals(item, existingItem);
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key)
+        => _itemsByKey.ContainsKey(key);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            TItem[] array,
+            int     arrayIndex)
+        => _itemsByKey.Values.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc cref="Dictionary{TKey, TItem}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _itemsByKey.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TItem>.ValueCollection.Enumerator GetEnumerator()
+        => _itemsByKey.Values.GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool Remove(TItem item)
+    {
+        var key = _keySelector.Invoke(item);
+
+        if (!_itemsByKey.TryGetValue(key, out var existingItem)
+                || !_itemComparer.Equals(item, existingItem))
+            return false;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.AddChange(KeyedChange.Removal(key, item));
+            if (_itemsByKey.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        if (!_itemsByKey.TryGetValue(key, out var value))
+            return false;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.AddChange(KeyedChange.Removal(key, value));
+            if (_itemsByKey.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TItem> items)
+    {
+        if (_itemsByKey.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled && items.TryGetNonEnumeratedCount(out var itemCount))
+            _changeCollector.EnsureCapacity(itemCount);
+
+        var wereItemsRemoved = false;
+        foreach (var item in items)
+            wereItemsRemoved |= Remove(item);
+
+        if ((_isChangeCollectionEnabled) && wereItemsRemoved && (_itemsByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TItem> items)
+    {
+        if (_itemsByKey.Count is 0)
+            return;
+
+        _changeCollector.EnsureCapacity(items.Length);
+
+        var wereItemsRemoved = false;
+        foreach (var item in items)
+            wereItemsRemoved |= Remove(item);
+
+        if ((_isChangeCollectionEnabled) && wereItemsRemoved && (_itemsByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TKey> keys)
+    {
+        if (_itemsByKey.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled && keys.TryGetNonEnumeratedCount(out var keyCount))
+            _changeCollector.EnsureCapacity(keyCount);
+
+        var wereKeysRemoved = false;
+        foreach (var key in keys)
+            wereKeysRemoved |= Remove(key);
+
+        if ((_isChangeCollectionEnabled) && wereKeysRemoved && (_itemsByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TKey> keys)
+    {
+        if (_itemsByKey.Count is 0)
+            return;
+
+        _changeCollector.EnsureCapacity(keys.Length);
+
+        var wereKeysRemoved = false;
+        foreach (var key in keys)
+            wereKeysRemoved |= Remove(key);
+
+        if ((_isChangeCollectionEnabled) && wereKeysRemoved && (_itemsByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<TItem> items)
+    {
+        Clear();
+        AddOrReplaceRange(items);
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<TItem> values)
+    {
+        Clear();
+        AddOrReplaceRange(values);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetItem(
+                                        TKey    key,
+            [MaybeNullWhen(false)]  out TItem   item)
+        => _itemsByKey.TryGetValue(key, out item);
+
+    IReadOnlyCollection<TKey> ICache<TKey, TItem>.Keys
+        => _itemsByKey.Keys;
+
+    IReadOnlyCollection<TKey> IReadOnlyCache<TKey, TItem>.Keys
+        => _itemsByKey.Keys;
+
+    bool ICollection<TItem>.IsReadOnly
+        => false;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _itemsByKey.Values.GetEnumerator();
+
+    IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
+        => _itemsByKey.Values.GetEnumerator();
+}

--- a/src/DynamicDataVNext/Keyed/ChangeTrackingDictionary.cs
+++ b/src/DynamicDataVNext/Keyed/ChangeTrackingDictionary.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// A collection of items, with distinct keys, which tracks and allows for capturing of changes made to it, as they occur.
+/// </summary>
+/// <typeparam name="TKey">The type of the item keys in the collection.</typeparam>
+/// <typeparam name="TValue">The type of the item values in the collection.</typeparam>
+public sealed class ChangeTrackingDictionary<TKey, TValue>
+        : IExtendedDictionary<TKey, TValue>,
+            IReadOnlyDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly KeyedChangeSet.Builder<TKey, TValue>   _changeCollector;
+    private readonly IEqualityComparer<TValue>              _valueComparer;
+    private readonly Dictionary<TKey, TValue>               _valuesByKey;
+
+    private bool _isChangeCollectionEnabled;
+    private bool _isDirty;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="ChangeTrackingDictionary{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="keyComparer">The comparer to be used for matching keys against each other, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    /// <param name="valueComparer">The comparer to be used for detecting value changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public ChangeTrackingDictionary(
+        int?                        capacity        = null,
+        IEqualityComparer<TKey>?    keyComparer     = null,
+        IEqualityComparer<TValue>?  valueComparer   = null)
+    {
+        _valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+
+        _valuesByKey = (capacity is int givenCapacity)
+            ? new(
+                capacity:   givenCapacity,
+                comparer:   keyComparer)
+            : new(
+                comparer:   keyComparer);
+
+        _changeCollector = new();
+        _isChangeCollectionEnabled = true;
+    }
+
+    /// <inheritdoc/>
+    public TValue this[TKey key]
+    {
+        get => _valuesByKey[key];
+        set
+        {
+            var wasKeyFound = _valuesByKey.TryGetValue(key, out var oldValue);
+
+            if (wasKeyFound && _valueComparer.Equals(oldValue, value))
+                return;
+
+            _valuesByKey[key] = value;
+
+            if (_isChangeCollectionEnabled)
+                _changeCollector.AddChange(wasKeyFound
+                    ? KeyedChange.Replacement(
+                        key:        key,
+                        oldItem:    oldValue!,
+                        newItem:    value)
+                    : KeyedChange.Addition(key, value));
+
+            _isDirty = true;
+        }
+    }
+
+    /// <inheritdoc/>
+    public int Count
+        => _valuesByKey.Count;
+
+    /// <summary>
+    /// A flag indicating whether the collection should actually collect changes, to be retrieved by calls to <see cref="CaptureChangesAndClean"/>.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note that any changes previously collected, but not captured, when this property is set to <see langword="false"/> will be discarded. Otherwise, it would be possible for <see cref="CaptureChangesAndClean"/> to generate a corrupt changes, when next called, after setting this property back to <see langword="true"/>.
+    /// </remarks>
+    public bool IsChangeCollectionEnabled
+    { 
+        get => _isChangeCollectionEnabled;
+        set
+        {
+            if ((value is false) && (_changeCollector.Count is not 0))
+                _changeCollector.Clear();
+
+            _isChangeCollectionEnabled = value;
+        }
+    }
+
+    /// <summary>
+    /// A flag indicating whether changes have been made to the collection since its creation, or since the last call to `<see cref="CaptureChangesAndClean"/>.
+    /// </summary>
+    public bool IsDirty
+        => _isDirty;
+
+    /// <summary>
+    /// The comparer to be used for matching key values against each other.
+    /// </summary>
+    public IEqualityComparer<TKey> KeyComparer
+        => _valuesByKey.Comparer;
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TValue>.KeyCollection Keys
+        => _valuesByKey.Keys;
+
+    /// <summary>
+    /// The comparer to be used for detecting value changes, within the collection.
+    /// </summary>
+    public IEqualityComparer<TValue> ValueComparer
+        => _valueComparer;
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TValue>.ValueCollection Values
+        => _valuesByKey.Values;
+
+    /// <inheritdoc/>
+    public void Add(
+        TKey    key,
+        TValue  value)
+    {
+        _valuesByKey.Add(key, value);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.AddChange(KeyedChange.Addition(key, value));
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void Add(KeyValuePair<TKey, TValue> item)
+        => Add(item.Key, item.Value);
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector)
+    {
+        ArgumentNullException.ThrowIfNull(values,       nameof(values));
+        ArgumentNullException.ThrowIfNull(keySelector,  nameof(keySelector));
+
+        if (values.TryGetNonEnumeratedCount(out var valueCount))
+        {
+            _valuesByKey.EnsureCapacity(_valuesByKey.Count + valueCount);
+
+            if (_isChangeCollectionEnabled)
+                _changeCollector.EnsureCapacity(_changeCollector.Count + valueCount);
+        }
+
+        foreach (var value in values)
+        {
+            var key = keySelector.Invoke(value);
+
+            this[key] = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector)
+    {
+        ArgumentNullException.ThrowIfNull(keySelector, nameof(keySelector));
+
+        _valuesByKey.EnsureCapacity(_valuesByKey.Count + values.Length);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.EnsureCapacity(_changeCollector.Count + values.Length);
+
+        foreach (var value in values)
+        {
+            var key = keySelector.Invoke(value);
+
+            this[key] = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        ArgumentNullException.ThrowIfNull(items, nameof(items));
+
+        if (items.TryGetNonEnumeratedCount(out var itemCount))
+        {
+            _valuesByKey.EnsureCapacity(_valuesByKey.Count + itemCount);
+
+            if (_isChangeCollectionEnabled)
+                _changeCollector.EnsureCapacity(_changeCollector.Count + itemCount);
+        }
+
+        foreach (var item in items)
+            this[item.Key] = item.Value;
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(ReadOnlySpan<KeyValuePair<TKey, TValue>> items)
+    {
+        _valuesByKey.EnsureCapacity(_valuesByKey.Count + items.Length);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.EnsureCapacity(_changeCollector.Count + items.Length);
+
+        foreach (var item in items)
+            this[item.Key] = item.Value;
+    }
+
+    /// <summary>
+    /// Captures any previously-collected changes made to the collection, and resets the collection to a "clean" state (I.E. sets <see cref="IsDirty"/> to <see langword="false"/>).
+    /// </summary>
+    /// <returns>A <see cref="KeyedChangeSet{TKey, TItem}"/> containing all changes made to the collection since its construction, the last call to <see cref="CaptureChangesAndClean"/>, or since <see cref="IsChangeCollectionEnabled"/> was last changed to <see langword="true"/>.</returns>
+    /// <remarks>
+    /// Note that this method will always return an empty changeset, when <see cref="IsChangeCollectionEnabled"/> is <see langword="false"/>.
+    /// </remarks>
+    public KeyedChangeSet<TKey, TValue> CaptureChangesAndClean()
+    {
+        _isDirty = false;
+        return _changeCollector.BuildAndClear();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (_valuesByKey.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.EnsureCapacity(_valuesByKey.Count);
+
+            foreach (var item in _valuesByKey)
+                _changeCollector.AddChange(KeyedChange.Removal(item.Key, item.Value));
+
+            _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+        => _valuesByKey.TryGetValue(item.Key, out var value)
+            && _valueComparer.Equals(item.Value, value);
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key)
+        => _valuesByKey.ContainsKey(key);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            KeyValuePair<TKey, TValue>[]    array,
+            int                             arrayIndex)
+        => ((ICollection<KeyValuePair<TKey, TValue>>)_valuesByKey).CopyTo(array, arrayIndex);
+
+    /// <inheritdoc cref="Dictionary{TKey, TValue}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _valuesByKey.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        if (!_valuesByKey.TryGetValue(key, out var value))
+            return false;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.AddChange(KeyedChange.Removal(key, value));
+            if (_valuesByKey.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+    {
+        if (!_valuesByKey.Contains(item))
+            return false;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _changeCollector.AddChange(KeyedChange.Removal(item.Key, item.Value));
+            if (_valuesByKey.Count is 0)
+                _changeCollector.OnSourceCleared();
+        }
+
+        _isDirty = true;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TKey> keys)
+    {
+        if (_valuesByKey.Count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled && keys.TryGetNonEnumeratedCount(out var keyCount))
+            _changeCollector.EnsureCapacity(keyCount);
+
+        var wereKeysRemoved = false;
+        foreach (var key in keys)
+            wereKeysRemoved |= Remove(key);
+
+        if ((_isChangeCollectionEnabled) && wereKeysRemoved && (_valuesByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TKey> keys)
+    {
+        if (_valuesByKey.Count is 0)
+            return;
+
+        _changeCollector.EnsureCapacity(keys.Length);
+
+        var wereKeysRemoved = false;
+        foreach (var key in keys)
+            wereKeysRemoved |= Remove(key);
+
+        if ((_isChangeCollectionEnabled) && wereKeysRemoved && (_valuesByKey.Count is 0))
+            _changeCollector.OnSourceCleared();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector)
+    {
+        Clear();
+        AddOrReplaceRange(values, keySelector);
+    }
+
+    /// <inheritdoc/>
+    public void Reset(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector)
+    {
+        Clear();
+        AddOrReplaceRange(values, keySelector);
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        Clear();
+        AddOrReplaceRange(items);
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<KeyValuePair<TKey, TValue>> items)
+    {
+        Clear();
+        AddOrReplaceRange(items);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(
+                                        TKey    key,
+            [MaybeNullWhen(false)]  out TValue  value)
+        => _valuesByKey.TryGetValue(key, out value);
+
+    bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
+        => false;
+
+    ICollection<TKey> IDictionary<TKey, TValue>.Keys
+        => _valuesByKey.Keys;
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+        => _valuesByKey.Keys;
+
+    IReadOnlyCollection<TKey> IExtendedDictionary<TKey, TValue>.Keys
+        => _valuesByKey.Keys;
+
+    ICollection<TValue> IDictionary<TKey, TValue>.Values
+        => _valuesByKey.Values;
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+        => _valuesByKey.Values;
+
+    IReadOnlyCollection<TValue> IExtendedDictionary<TKey, TValue>.Values
+        => _valuesByKey.Values;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+}

--- a/src/DynamicDataVNext/Keyed/ICache.cs
+++ b/src/DynamicDataVNext/Keyed/ICache.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// Describes a collection of distinctly-keyed items.
+/// </summary>
+/// <typeparam name="TKey">The type of the key values of items in the collection.</typeparam>
+/// <typeparam name="TItem">The type of the items in the collection.</typeparam>
+public interface ICache<TKey, TItem>
+    : ICollection<TItem>
+{
+    /// <summary>
+    /// Retrieves the item in the collection for the given key.
+    /// </summary>
+    /// <param name="key">The key of the item to be retrieved.</param>
+    /// <exception cref="KeyNotFoundException">Throws when <paramref name="key"/> does not exist within the collection.</exception>
+    /// <returns>The item in the collection with the given key.</returns>
+    TItem this[TKey key] { get; }
+
+    /// <summary>
+    /// Retrieves the current set of keys present within the collection.
+    /// </summary>
+    /// <remarks>
+    /// Note that the returned collection represents a "snapshot" of the source collection, at the time at which it is created. Changes made to the source collection after a key collection is retrieved are not reflected upon the key collection.
+    /// </remarks>
+    IReadOnlyCollection<TKey> Keys { get; }
+
+    /// <summary>
+    /// Applies an item to the collection, as a single operation, by either adding or replacing the item, based on its key value.
+    /// </summary>
+    /// <param name="item">The item to be applied to the collection.</param>
+    void AddOrReplace(TItem item);
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its key value.
+    /// </summary>
+    /// <param name="items">The items to applied to the collection.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void AddOrReplaceRange(IEnumerable<TItem> items);
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its key value.
+    /// </summary>
+    /// <param name="items">The items to applied to the collection.</param>
+    void AddOrReplaceRange(ReadOnlySpan<TItem> items);
+
+    /// <summary>
+    /// Checks whether a given key is currently present, within the collection.
+    /// </summary>
+    /// <param name="key">The key to check for.</param>
+    /// <returns>A flag indicating whether the given key is present in the collection, or not.</returns>
+    bool ContainsKey(TKey key);
+
+    /// <summary>
+    /// Removes an item from the collection, by its key.
+    /// </summary>
+    /// <param name="key">The key to be removed.</param>
+    /// <returns>A flag indicating whether the given key was present in the collection, and thus removed successfully, or not.</returns>
+    bool Remove(TKey key);
+
+    /// <summary>
+    /// Removes a set of items, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items to be removed.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    /// <remarks>
+    /// Note that the collection will silently ignore items that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(IEnumerable<TItem> items);
+
+    /// <summary>
+    /// Removes a set of items, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items to be removed.</param>
+    /// <remarks>
+    /// Note that the collection will silently ignore items that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(ReadOnlySpan<TItem> items);
+
+    /// <summary>
+    /// Removes a set of items, by key, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="keys">The set of keys to be removed.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
+    /// <remarks>
+    /// Note that the collection will silently ignore keys that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(IEnumerable<TKey> keys);
+
+    /// <summary>
+    /// Removes a set of items, by key, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="keys">The set of keys to be removed.</param>
+    /// <remarks>
+    /// Note that the collection will silently ignore keys that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(ReadOnlySpan<TKey> keys);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items with which to populate the collection.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void Reset(IEnumerable<TItem> items);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The set of items with which to populate the collection.</param>
+    void Reset(ReadOnlySpan<TItem> items);
+
+    /// <summary>
+    /// Attempts to retrieve an item from the collection, by its key.
+    /// </summary>
+    /// <param name="key">The key whose item is to be retrieved.</param>
+    /// <param name="item">The item in the collection whose key is <paramref name="key"/>. The default value of <typeparamref name="TItem"/> is assigned, if no such item is present.</param>
+    /// <returns>A flag indicating whether an item with the given key was successfully retrieved, or not.</returns>
+    bool TryGetItem(TKey key, [MaybeNullWhen(false)] out TItem item);
+}

--- a/src/DynamicDataVNext/Keyed/IExtendedDictionary.cs
+++ b/src/DynamicDataVNext/Keyed/IExtendedDictionary.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// Describes an extended version of <see cref="IDictionary{TKey, TValue}"/>, supporting range operations.
+/// </summary>
+/// <typeparam name="TKey">The type of the item keys in the collection.</typeparam>
+/// <typeparam name="TValue">The type of the item values in the collection.</typeparam>
+/// <remarks>
+/// It's worth noting that the lack of an AddRange() method on this interface is intentional. Such a method would intuitively need to follow the pattern of <see cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/> and throw an exception when a key is presented that is already present in the collection, which would then introduce the possibility for an AddRange() operation to only be half-applied to the collection. The most appropriate thing to do would be to roll back any items already added to the collection, when the exception is thrown, which would require quite a lot of additional state tracking and item iteration. The <see cref="AddOrReplaceRange(IEnumerable{KeyValuePair{TKey, TValue}})"/> should usually be preferred, for adding batches of items to a collection, and if key validation is desired, it can be implemented on the consumer's end.
+/// </remarks>
+public interface IExtendedDictionary<TKey, TValue>
+    : IDictionary<TKey, TValue>
+{
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Keys"/>
+    new IReadOnlyCollection<TKey> Keys { get; }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Values"/>
+    new IReadOnlyCollection<TValue> Values { get; }
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its selected key value.
+    /// </summary>
+    /// <param name="values">The values to use as <see cref="KeyValuePair{TKey, TValue}.Value"/> for each applied item.</param>
+    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each applied item.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="values"/> and <paramref name="keySelector"/>.</exception>
+    void AddOrReplaceRange(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector);
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its selected key value.
+    /// </summary>
+    /// <param name="values">The values to use as <see cref="KeyValuePair{TKey, TValue}.Value"/> for each applied item.</param>
+    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each applied item.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keySelector"/>.</exception>
+    void AddOrReplaceRange(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector);
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its key value.
+    /// </summary>
+    /// <param name="items">The keys and values to be applied.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void AddOrReplaceRange(IEnumerable<KeyValuePair<TKey, TValue>> items);
+
+    /// <summary>
+    /// Applies a range of items to the collection, as a single operation, by either adding or replacing each item, based on its key value.
+    /// </summary>
+    /// <param name="items">The keys and values to be applied.</param>
+    void AddOrReplaceRange(ReadOnlySpan<KeyValuePair<TKey, TValue>> items);
+
+    /// <summary>
+    /// Removes a set of items, by key, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="keys">The set of keys to be removed.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
+    /// <remarks>
+    /// Note that the collection will silently ignore keys that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(IEnumerable<TKey> keys);
+
+    /// <summary>
+    /// Removes a set of items, by key, from the collection, as a single operation.
+    /// </summary>
+    /// <param name="keys">The set of keys to be removed.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
+    /// <remarks>
+    /// Note that the collection will silently ignore keys that are not present in the collection.
+    /// </remarks>
+    void RemoveRange(ReadOnlySpan<TKey> keys);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="values">The set of items with which to populate the collection.</param>
+    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each new item.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="values"/> and <paramref name="keySelector"/>.</exception>
+    void Reset(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="values">The set of items with which to populate the collection.</param>
+    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each new item.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keySelector"/>.</exception>
+    void Reset(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The keys vand values to be added.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
+    void Reset(IEnumerable<KeyValuePair<TKey, TValue>> items);
+
+    /// <summary>
+    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
+    /// </summary>
+    /// <param name="items">The keys vand values to be added.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
+    void Reset(ReadOnlySpan<KeyValuePair<TKey, TValue>> items);
+}

--- a/src/DynamicDataVNext/Keyed/IObservableCache.cs
+++ b/src/DynamicDataVNext/Keyed/IObservableCache.cs
@@ -1,79 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 
 namespace DynamicDataVNext;
 
 /// <summary>
-/// Describes a collection of distinctly-keyed items, which publishes notifications about its mutations to subscribers, as they occur.
+/// Describes a collection of distinctly-keyed items, which may not be mutated by the consumer, and which publishes notifications about its mutations to subscribers, as they occur.
 /// </summary>
 /// <typeparam name="TKey">The type of the key values of items in the collection.</typeparam>
 /// <typeparam name="TItem">The type of the items in the collection.</typeparam>
 public interface IObservableCache<TKey, TItem>
-    : IReadOnlyCollection<TItem>,
-        IObservable<KeyedChange<TKey, TItem>>
+    : IReadOnlyCache<TKey, TItem>,
+        IObservable<KeyedChangeSet<TKey, TItem>>
 {
-    /// <summary>
-    /// retrieves the item in the collection (if any) for the given key.
-    /// </summary>
-    /// <param name="key">The key of the item to be retrieved.</param>
-    /// <exception cref="KeyNotFoundException">Throws when <paramref name="key"/> does not exist within the collection.</exception>
-    /// <returns>The item in the collection with the given key.</returns>
-    TItem this[TKey key] { get; }
-    
-    /// <summary>
-    /// Retrieves the current set of keys present within the collection.
-    /// </summary>
-    /// <remarks>
-    /// Note that the returned collection represents a "snapshot" of the source collection, at the time at which it is created. Changes made to the source collection after a key collection is retrieved are not reflected upon the key collection.
-    /// </remarks>
-    IReadOnlyCollection<TKey> Keys { get; }
-
-    /// <summary>
-    /// Retrieves the current set of items present within the collection.
-    /// </summary>
-    /// <remarks>
-    /// Note that the returned collection represents a "snapshot" of the source collection, at the time at which it is created. Changes made to the source collection after an item collection is retrieved are not reflected upon the item collection.
-    /// </remarks>
-    IReadOnlyCollection<TItem> Items { get; }
-
-    /// <summary>
-    /// An event that occurs after any mutation of the collection occurs.
-    /// </summary>
+    /// <inheritdoc cref="ISubjectCache{TKey, TItem}.CollectionChanged"/>
     IObservable<Unit> CollectionChanged { get; }
 
-    /// <summary>
-    /// Checks whether a given key is currently present, within the collection.
-    /// </summary>
-    /// <param name="key">The key to check for.</param>
-    /// <returns>A flag indicating whether the given key is present in the collection, or not.</returns>
-    bool ContainsKey(TKey key);
-
-    /// <summary>
-    /// Allows subscribers to observe the value of a particular keyed item within the collection, as it changes.
-    /// </summary>
-    /// <param name="key">The key whose value is to be observed.</param>
-    /// <returns>A stream which will publish the latest value, for the given key, within the collection.</returns>
-    /// <remarks>
-    /// The returned stream will always immediately publish the current value for the given key, upon subscription, and will complete if the given key is removed. If the key is not present within the collection upon subscription, the stream will complete immediately.
-    /// </remarks>
+    /// <inheritdoc cref="ISubjectCache{TKey, TItem}.ObserveValue(TKey)"/>
     IObservable<TItem> ObserveValue(TKey key);
-
-    /// <summary>
-    /// Attempts to retrieve an item from the collection, by its key.
-    /// </summary>
-    /// <param name="key">The key whose item is to be retrieved.</param>
-    /// <param name="item">The item in the collection whose key is <paramref name="key"/>. The default value of <typeparamref name="TItem"/> is assigned, if no such item is present.</param>
-    /// <returns>A flag indicating whether an item with the given key was successfully retrieved, or not.</returns>
-    bool TryGetItem(TKey key, [MaybeNullWhen(false)] out TItem item);
-
-    /// <summary>
-    /// Temporarily suspends the publication of notifications by the collection, until the returned object is disposed, at which point all mutations made during the suspension will (if any) will be published as one notification.
-    /// </summary>
-    /// <returns>An object that will trigger the resumption of notifications, when disposed.</returns>
-    /// <remarks>
-    /// May be called multiple times, in which case no notifications will be published until all outstanding suspensions have been disposed.
-    /// </remarks>
-    IDisposable SuspendNotifications();
 }

--- a/src/DynamicDataVNext/Keyed/IObservableDictionary.cs
+++ b/src/DynamicDataVNext/Keyed/IObservableDictionary.cs
@@ -11,7 +11,7 @@ namespace DynamicDataVNext;
 /// <typeparam name="TValue">The type of the item values in the collection.</typeparam>
 public interface IObservableDictionary<TKey, TValue>
     : IReadOnlyDictionary<TKey, TValue>,
-        IObservable<KeyedChange<TKey, TValue>>
+        IObservable<KeyedChangeSet<TKey, TValue>>
 {
     /// <inheritdoc cref="ISubjectDictionary{TKey, TValue}.CollectionChanged"/>
     IObservable<Unit> CollectionChanged { get; }
@@ -24,7 +24,4 @@ public interface IObservableDictionary<TKey, TValue>
 
     /// <inheritdoc cref="ISubjectDictionary{TKey, TValue}.ObserveValue(TKey)"/>
     IObservable<TValue> ObserveValue(TKey key);
-
-    /// <inheritdoc cref="ISubjectDictionary{TKey, TValue}.SuspendNotifications"/>
-    IDisposable SuspendNotifications();
 }

--- a/src/DynamicDataVNext/Keyed/IReadOnlyCache.cs
+++ b/src/DynamicDataVNext/Keyed/IReadOnlyCache.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// Describes a collection of distinctly-keyed items, which does not allow public mutation.
+/// </summary>
+/// <typeparam name="TKey">The type of the key values of items in the collection.</typeparam>
+/// <typeparam name="TItem">The type of the items in the collection.</typeparam>
+public interface IReadOnlyCache<TKey, TItem>
+    : IReadOnlyCollection<TItem>
+{
+    /// <inheritdoc cref="ICache{TKey, TItem}.this[TKey]"/>
+    TItem this[TKey key] { get; }
+
+    /// <inheritdoc cref="ICache{TKey, TItem}.Keys"/>
+    IReadOnlyCollection<TKey> Keys { get; }
+
+    /// <inheritdoc cref="ICache{TKey, TItem}.ContainsKey(TKey)"/>
+    bool ContainsKey(TKey key);
+
+    /// <inheritdoc cref="ICache{TKey, TItem}.TryGetItem(TKey, out TItem)"/>
+    bool TryGetItem(TKey key, [MaybeNullWhen(false)] out TItem item);
+}

--- a/src/DynamicDataVNext/Keyed/ISubjectCache.cs
+++ b/src/DynamicDataVNext/Keyed/ISubjectCache.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 
 namespace DynamicDataVNext;
@@ -11,55 +9,13 @@ namespace DynamicDataVNext;
 /// <typeparam name="TKey">The type of the key values of items in the collection.</typeparam>
 /// <typeparam name="TItem">The type of the items in the collection.</typeparam>
 public interface ISubjectCache<TKey, TItem>
-    : ICollection<TItem>,
-        IObservable<KeyedChange<TKey, TItem>>
+    : ICache<TKey, TItem>,
+        IObservable<KeyedChangeSet<TKey, TItem>>
 {
-    /// <summary>
-    /// Accesses the item in the collection (if any) for the given key.
-    /// </summary>
-    /// <param name="key">The key of the item to be accessed.</param>
-    /// <exception cref="KeyNotFoundException">Throws when <paramref name="key"/> does not exist within the collection, during a retrieval.</exception>
-    /// <returns>The item in the collection with the given key.</returns>
-    /// <remarks>
-    /// When assigning a value to a given key, the key need not be already-present within the collection.
-    /// </remarks>
-    TItem this[TKey key] { get; set; }
-    
-    /// <summary>
-    /// Retrieves the current set of keys present within the collection.
-    /// </summary>
-    /// <remarks>
-    /// Note that the returned collection represents a "snapshot" of the source collection, at the time at which it is created. Changes made to the source collection after a key collection is retrieved are not reflected upon the key collection.
-    /// </remarks>
-    IReadOnlyCollection<TKey> Keys { get; }
-
-    /// <summary>
-    /// Retrieves the current set of items present within the collection.
-    /// </summary>
-    /// <remarks>
-    /// Note that the returned collection represents a "snapshot" of the source collection, at the time at which it is created. Changes made to the source collection after an item collection is retrieved are not reflected upon the item collection.
-    /// </remarks>
-    IReadOnlyCollection<TItem> Items { get; }
-
-    /// <summary>
-    /// Adds a range of items to the collection, as a single operation.
-    /// </summary>
-    /// <param name="items">The items to be added.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
-    /// <exception cref="ArgumentException">Throws if <paramref name="items"/> contains an item whose key is already present within the collection.</exception>
-    void AddRange(IEnumerable<TItem> items);
-
     /// <summary>
     /// An event that occurs after any mutation of the collection occurs.
     /// </summary>
     IObservable<Unit> CollectionChanged { get; }
-
-    /// <summary>
-    /// Checks whether a given key is currently present, within the collection.
-    /// </summary>
-    /// <param name="key">The key to check for.</param>
-    /// <returns>A flag indicating whether the given key is present in the collection, or not.</returns>
-    bool ContainsKey(TKey key);
 
     /// <summary>
     /// Allows subscribers to observe the value of a particular keyed item within the collection, as it changes.
@@ -70,38 +26,6 @@ public interface ISubjectCache<TKey, TItem>
     /// The returned stream will always immediately publish the current value for the given key, upon subscription, and will complete if the given key is removed. If the key is not present within the collection upon subscription, the stream will complete immediately.
     /// </remarks>
     IObservable<TItem> ObserveValue(TKey key);
-
-    /// <summary>
-    /// Removes an item from the collection, by its key.
-    /// </summary>
-    /// <param name="key">The key to be removed.</param>
-    /// <returns>A flag indicating whether the given key was present in the collection, and thus removed successfully, or not.</returns>
-    bool Remove(TKey key);
-
-    /// <summary>
-    /// Removes a set of items, by key, from the collection, as a single operation.
-    /// </summary>
-    /// <param name="keys">The set of keys to be removed.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
-    /// <remarks>
-    /// Note that the collection will silently ignore keys that are not present in the collection.
-    /// </remarks>
-    void RemoveRange(IEnumerable<TKey> keys);
-
-    /// <summary>
-    /// Attempts to retrieve an item from the collection, by its key.
-    /// </summary>
-    /// <param name="key">The key whose item is to be retrieved.</param>
-    /// <param name="item">The item in the collection whose key is <paramref name="key"/>. The default value of <typeparamref name="TItem"/> is assigned, if no such item is present.</param>
-    /// <returns>A flag indicating whether an item with the given key was successfully retrieved, or not.</returns>
-    bool TryGetItem(TKey key, [MaybeNullWhen(false)] out TItem item);
-
-    /// <summary>
-    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
-    /// </summary>
-    /// <param name="items">The set of items with which to populate the collection.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
-    void Reset(IEnumerable<TItem> items);
 
     /// <summary>
     /// Temporarily suspends the publication of notifications by the collection, until the returned object is disposed, at which point all mutations made during the suspension will (if any) will be published as one notification.

--- a/src/DynamicDataVNext/Keyed/ISubjectDictionary.cs
+++ b/src/DynamicDataVNext/Keyed/ISubjectDictionary.cs
@@ -10,30 +10,13 @@ namespace DynamicDataVNext;
 /// <typeparam name="TKey">The type of the item keys in the collection.</typeparam>
 /// <typeparam name="TValue">The type of the item values in the collection.</typeparam>
 public interface ISubjectDictionary<TKey, TValue>
-    : IDictionary<TKey, TValue>,
-        IObservable<KeyedChange<TKey, TValue>>
+    : IExtendedDictionary<TKey, TValue>,
+        IObservable<KeyedChangeSet<TKey, TValue>>
 {
     /// <summary>
     /// An event that occurs after any mutation of the collection occurs.
     /// </summary>
     IObservable<Unit> CollectionChanged { get; }
-
-    /// <inheritdoc cref="IDictionary{TKey, TValue}.Keys"/>
-    new IReadOnlyCollection<TKey> Keys { get; }
-
-    /// <inheritdoc cref="IDictionary{TKey, TValue}.Values"/>
-    new IReadOnlyCollection<TValue> Values { get; }
-
-    /// <summary>
-    /// Adds a range of items to the collection, as a single operation.
-    /// </summary>
-    /// <param name="values">The values to use as <see cref="KeyValuePair{TKey, TValue}.Value"/> for each new item.</param>
-    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each new item.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="values"/> and <paramref name="keySelector"/>.</exception>
-    /// <exception cref="ArgumentException">Throws if <paramref name="keySelector"/> returns a key that already exists within the collection.</exception>
-    void AddRange(
-        IEnumerable<TValue> values,
-        Func<TValue, TKey>  keySelector);
 
     /// <summary>
     /// Allows subscribers to observe the value of a particular keyed item within the collection, as it changes.
@@ -44,26 +27,6 @@ public interface ISubjectDictionary<TKey, TValue>
     /// The returned stream will always immediately publish the current value for the given key, upon subscription, and will complete if the given key is removed. If the key is not present within the collection upon subscription, the stream will complete immediately.
     /// </remarks>
     IObservable<TValue> ObserveValue(TKey key);
-
-    /// <summary>
-    /// Removes a set of items, by key, from the collection, as a single operation.
-    /// </summary>
-    /// <param name="keys">The set of keys to be removed.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="keys"/>.</exception>
-    /// <remarks>
-    /// Note that the collection will silently ignore keys that are not present in the collection.
-    /// </remarks>
-    void RemoveRange(IEnumerable<TKey> keys);
-
-    /// <summary>
-    /// Resets the items within the collection to the given set of items. I.E. clears and then re-populates the collection, as a single operation.
-    /// </summary>
-    /// <param name="values">The set of items with which to populate the collection.</param>
-    /// <param name="keySelector">A selector to select a <see cref="KeyValuePair{TKey, TValue}.Key"/> value for each new item.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="values"/> and <paramref name="keySelector"/>.</exception>
-    void Reset(
-        IEnumerable<TValue> values,
-        Func<TValue, TKey>  keySelector);
 
     /// <summary>
     /// Temporarily suspends the publication of notifications by the collection, until the returned object is disposed, at which point all mutations made during the suspension will (if any) will be published as one notification.

--- a/src/DynamicDataVNext/Keyed/SubjectCache.cs
+++ b/src/DynamicDataVNext/Keyed/SubjectCache.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// The basic implementation of <see cref="ISubjectCache{TKey, TItem}"/>, providing simple collection and change notification functionality, with no concurrency or thread-safety.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public sealed class SubjectCache<TKey, TItem>
+        : ISubjectCache<TKey, TItem>,
+            IObservableCache<TKey, TItem>,
+            IDisposable
+    where TKey : notnull
+{
+    private readonly Subject<KeyedChangeSet<TKey, TItem>>   _changeStream;
+    private readonly Subject<Unit>                          _collectionChanged;
+    private readonly Subject<Unit>                          _notificationsResumed;
+    private readonly Action                                 _onChangeStreamFinalized;
+    private readonly ChangeTrackingCache<TKey, TItem>       _items;
+
+    private int _notificationSuspensionCount;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SubjectCache{TKey, TItem}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="keyComparer">The comparer to be used for matching keys against each other, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    /// <param name="itemComparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public SubjectCache(
+        Func<TItem, TKey>           keySelector,
+        int?                        capacity        = null,
+        IEqualityComparer<TKey>?    keyComparer     = null,
+        IEqualityComparer<TItem>?   itemComparer    = null)
+    {
+        _collectionChanged      = new();
+        _changeStream           = new();
+        _notificationsResumed   = new();
+        _items                  = new(
+            keySelector:    keySelector,
+            capacity:       capacity,
+            keyComparer:    keyComparer,
+            itemComparer:   itemComparer);
+
+        _onChangeStreamFinalized = () => _items.IsChangeCollectionEnabled = _changeStream.HasObservers;
+    }
+
+    /// <inheritdoc/>
+    public TItem this[TKey key]
+        => _items[key];
+
+    /// <inheritdoc/>
+    public IObservable<Unit> CollectionChanged
+        => _collectionChanged;
+
+    /// <inheritdoc/>
+    public int Count
+        => _items.Count;
+
+    /// <inheritdoc cref="ChangeTrackingDictionary{TKey, TItem}.ItemComparer"/>
+    public IEqualityComparer<TItem> ItemComparer
+        => _items.ItemComparer;
+
+    /// <inheritdoc cref="ChangeTrackingDictionary{TKey, TItem}.KeyComparer"/>
+    public IEqualityComparer<TKey> KeyComparer
+        => _items.KeyComparer;
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<TKey> Keys
+        => _items.Keys;
+
+    /// <inheritdoc/>
+    public void Add(TItem value)
+    {
+        _items.Add(value);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplace(TItem value)
+    {
+        _items.AddOrReplace(value);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(IEnumerable<TItem> values)
+    {
+        _items.AddOrReplaceRange(values);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(ReadOnlySpan<TItem> values)
+    {
+        _items.AddOrReplaceRange(values);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        _items.Clear();
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(TItem item)
+        => _items.Contains(item);
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key)
+        => _items.ContainsKey(key);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            TItem[] array,
+            int     arrayIndex)
+        => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _changeStream           .OnCompleted();
+        _collectionChanged      .OnCompleted();
+        _notificationsResumed   .OnCompleted();
+
+        _changeStream           .Dispose();
+        _collectionChanged      .Dispose();
+        _notificationsResumed   .Dispose();
+    }
+
+    /// <inheritdoc cref="ChangeTrackingCache{TKey, TItem}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _items.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TItem>.ValueCollection.Enumerator GetEnumerator()
+        => _items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public IObservable<TItem> ObserveValue(TKey key)
+        => ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<TItem>()
+                : Observable.Never<TItem>()
+                    .TakeUntil(_notificationsResumed))
+            .Concat(Observable.Create<TItem>(observer =>
+            {
+                _items.IsChangeCollectionEnabled = true;
+
+                if (!_items.TryGetItem(key, out var initialItem))
+                {
+                    observer.OnCompleted();
+                    return Disposable.Empty;
+                }
+
+                observer.OnNext(initialItem);
+                return _changeStream
+                    .Finally(_onChangeStreamFinalized)
+                    .SubscribeSafe(Observer.Create<KeyedChangeSet<TKey, TItem>>(
+                        onNext:         changeSet =>
+                        {
+                            switch (changeSet.Type)
+                            {
+                                case ChangeSetType.Clear:
+                                    observer.OnCompleted();
+                                    break;
+
+                                case ChangeSetType.Reset:
+                                    if (_items.TryGetItem(key, out var item))
+                                        observer.OnNext(item);
+                                    else
+                                        observer.OnCompleted();
+                                    break;
+
+                                default:
+                                    foreach (var change in changeSet.Changes)
+                                    {
+                                        switch (change.Type)
+                                        {
+                                            case KeyedChangeType.Removal:
+                                                if (_items.KeyComparer.Equals(key, change.AsRemoval().Key))
+                                                    observer.OnCompleted();
+                                                break;
+
+                                            case KeyedChangeType.Replacement:
+                                                var replacement = change.AsReplacement();
+                                                if (_items.KeyComparer.Equals(key, replacement.Key))
+                                                    observer.OnNext(replacement.NewItem);
+                                                break;
+                                        }
+                                    }
+                                    break;
+                            }
+                        },
+                        onError:        observer.OnError,
+                        onCompleted:    observer.OnCompleted));
+            }));
+
+    /// <inheritdoc/>
+    public bool Remove(TItem item)
+    {
+        var result = _items.Remove(item);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        var result = _items.Remove(key);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TItem> items)
+    {
+        _items.RemoveRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TItem> items)
+    {
+        _items.RemoveRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TKey> keys)
+    {
+        _items.RemoveRange(keys);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TKey> keys)
+    {
+        _items.RemoveRange(keys);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<TItem> items)
+    {
+        _items.Reset(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<TItem> items)
+    {
+        _items.Reset(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<KeyedChangeSet<TKey, TItem>> observer)
+    {
+        _items.IsChangeCollectionEnabled = true;
+        
+        return ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<Unit>()
+                : _notificationsResumed
+                    .Take(1))
+            .Select(_ => _changeStream
+                .Finally(_onChangeStreamFinalized)
+                .Prepend(KeyedChangeSet.BulkAddition(_items, _items.KeySelector)))
+            .Switch()
+            .Subscribe(observer);
+    }
+
+    /// <inheritdoc/>
+    public NotificationSuspension SuspendNotifications()
+    {
+        ++_notificationSuspensionCount;
+        return new(this);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetItem(
+                                        TKey    key,
+            [MaybeNullWhen(false)]  out TItem   item)
+        => _items.TryGetItem(key, out item);
+
+    bool ICollection<TItem>.IsReadOnly
+        => false;
+
+    IReadOnlyCollection<TKey> ICache<TKey, TItem>.Keys
+        => _items.Keys;
+
+    IReadOnlyCollection<TKey> IReadOnlyCache<TKey, TItem>.Keys
+        => _items.Keys;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IDisposable ISubjectCache<TKey, TItem>.SuspendNotifications()
+        => SuspendNotifications();
+
+    private void OnNotificationSuspensionDisposed()
+    {
+        --_notificationSuspensionCount;
+        if (_notificationSuspensionCount is 0)
+        {
+            PublishPendingNotifications();
+
+            _notificationsResumed.OnNext(Unit.Default);
+        }
+    }
+
+    private void PublishPendingNotifications()
+    {
+        if ((_notificationSuspensionCount is not 0) || !_items.IsDirty)
+            return;
+
+        _collectionChanged.OnNext(Unit.Default);
+
+        _changeStream.OnNext(_items.CaptureChangesAndClean());
+    }
+
+    /// <summary>
+    /// A value that controls suspension of notifications, for a <see cref="SubjectDictionary{TKey, TItem}"/>. Will trigger notifications to be resumed, when disposed.
+    /// </summary>
+    public struct NotificationSuspension
+        : IDisposable
+    {
+        private SubjectCache<TKey, TItem>? _owner;
+
+        internal NotificationSuspension(SubjectCache<TKey, TItem> owner)
+            => _owner = owner;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_owner is not null)
+            {
+                _owner.OnNotificationSuspensionDisposed();
+                _owner = null;
+            }
+        }
+    }
+}

--- a/src/DynamicDataVNext/Keyed/SubjectDictionary.cs
+++ b/src/DynamicDataVNext/Keyed/SubjectDictionary.cs
@@ -1,0 +1,409 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// The basic implementation of <see cref="ISubjectDictionary{TKey, TValue}"/>, providing simple collection and change notification functionality, with no concurrency or thread-safety.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public sealed class SubjectDictionary<TKey, TValue>
+        : ISubjectDictionary<TKey, TValue>,
+            IObservableDictionary<TKey, TValue>,
+            IDisposable
+    where TKey : notnull
+{
+    private readonly Subject<KeyedChangeSet<TKey, TValue>>  _changeStream;
+    private readonly Subject<Unit>                          _collectionChanged;
+    private readonly Subject<Unit>                          _notificationsResumed;
+    private readonly Action                                 _onChangeStreamFinalized;
+    private readonly ChangeTrackingDictionary<TKey, TValue> _valuesByKey;
+
+    private int _notificationSuspensionCount;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SubjectDictionary{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="keyComparer">The comparer to be used for matching keys against each other, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    /// <param name="valueComparer">The comparer to be used for detecting value changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public SubjectDictionary(
+        int?                        capacity        = null,
+        IEqualityComparer<TKey>?    keyComparer     = null,
+        IEqualityComparer<TValue>?  valueComparer   = null)
+    {
+        _collectionChanged      = new();
+        _changeStream           = new();
+        _notificationsResumed   = new();
+        _valuesByKey            = new(
+            capacity:       capacity,
+            keyComparer:    keyComparer,
+            valueComparer:  valueComparer);
+
+        _onChangeStreamFinalized = () => _valuesByKey.IsChangeCollectionEnabled = _changeStream.HasObservers;
+    }
+
+    /// <inheritdoc/>
+    public TValue this[TKey key]
+    {
+        get => _valuesByKey[key];
+        set
+        {
+            _valuesByKey[key] = value;
+
+            PublishPendingNotifications();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IObservable<Unit> CollectionChanged
+        => _collectionChanged;
+
+    /// <inheritdoc/>
+    public int Count
+        => _valuesByKey.Count;
+
+    /// <inheritdoc cref="ChangeTrackingDictionary{TKey, TValue}.KeyComparer"/>
+    public IEqualityComparer<TKey> KeyComparer
+        => _valuesByKey.KeyComparer;
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<TKey> Keys
+        => _valuesByKey.Keys;
+
+    /// <inheritdoc cref="ChangeTrackingDictionary{TKey, TValue}.ValueComparer"/>
+    public IEqualityComparer<TValue> ValueComparer
+        => _valuesByKey.ValueComparer;
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<TValue> Values
+        => _valuesByKey.Values;
+
+    /// <inheritdoc/>
+    public void Add(TKey key, TValue value)
+    {
+        _valuesByKey.Add(key, value);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Add(KeyValuePair<TKey, TValue> item)
+    {
+        _valuesByKey.Add(item);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector)
+    {
+        _valuesByKey.AddOrReplaceRange(values, keySelector);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector)
+    {
+        _valuesByKey.AddOrReplaceRange(values, keySelector);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        _valuesByKey.AddOrReplaceRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddOrReplaceRange(ReadOnlySpan<KeyValuePair<TKey, TValue>> items)
+    {
+        _valuesByKey.AddOrReplaceRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        _valuesByKey.Clear();
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+        => _valuesByKey.Contains(item);
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key)
+        => _valuesByKey.ContainsKey(key);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            KeyValuePair<TKey, TValue>[]    array,
+            int                             arrayIndex)
+        => _valuesByKey.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _changeStream           .OnCompleted();
+        _collectionChanged      .OnCompleted();
+        _notificationsResumed   .OnCompleted();
+
+        _changeStream           .Dispose();
+        _collectionChanged      .Dispose();
+        _notificationsResumed   .Dispose();
+    }
+
+    /// <inheritdoc cref="ChangeTrackingDictionary{TKey, TValue}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _valuesByKey.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+
+    /// <inheritdoc/>
+    public IObservable<TValue> ObserveValue(TKey key)
+        => ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<TValue>()
+                : Observable.Never<TValue>()
+                    .TakeUntil(_notificationsResumed))
+            .Concat(Observable.Create<TValue>(observer =>
+            {
+                _valuesByKey.IsChangeCollectionEnabled = true;
+
+                if (!_valuesByKey.TryGetValue(key, out var initialValue))
+                {
+                    observer.OnCompleted();
+                    return Disposable.Empty;
+                }
+
+                observer.OnNext(initialValue);
+                return _changeStream
+                    .Finally(_onChangeStreamFinalized)
+                    .SubscribeSafe(Observer.Create<KeyedChangeSet<TKey, TValue>>(
+                        onNext:         changeSet =>
+                        {
+                            switch (changeSet.Type)
+                            {
+                                case ChangeSetType.Clear:
+                                    observer.OnCompleted();
+                                    break;
+
+                                case ChangeSetType.Reset:
+                                    if (_valuesByKey.TryGetValue(key, out var value))
+                                        observer.OnNext(value);
+                                    else
+                                        observer.OnCompleted();
+                                    break;
+
+                                default:
+                                    foreach (var change in changeSet.Changes)
+                                    {
+                                        switch (change.Type)
+                                        {
+                                            case KeyedChangeType.Removal:
+                                                if (_valuesByKey.KeyComparer.Equals(key, change.AsRemoval().Key))
+                                                    observer.OnCompleted();
+                                                break;
+
+                                            case KeyedChangeType.Replacement:
+                                                var replacement = change.AsReplacement();
+                                                if (_valuesByKey.KeyComparer.Equals(key, replacement.Key))
+                                                    observer.OnNext(replacement.NewItem);
+                                                break;
+                                        }
+                                    }
+                                    break;
+                            }
+                        },
+                        onError:        observer.OnError,
+                        onCompleted:    observer.OnCompleted));
+            }));
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        var result = _valuesByKey.Remove(key);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+    {
+        var result = _valuesByKey.Remove(item);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(IEnumerable<TKey> keys)
+    {
+        _valuesByKey.RemoveRange(keys);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(ReadOnlySpan<TKey> keys)
+    {
+        _valuesByKey.RemoveRange(keys);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(
+        IEnumerable<TValue> values,
+        Func<TValue, TKey>  keySelector)
+    {
+        _valuesByKey.Reset(values, keySelector);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(
+        ReadOnlySpan<TValue>    values,
+        Func<TValue, TKey>      keySelector)
+    {
+        _valuesByKey.Reset(values, keySelector);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        _valuesByKey.Reset(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Reset(ReadOnlySpan<KeyValuePair<TKey, TValue>> items)
+    {
+        _valuesByKey.Reset(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<KeyedChangeSet<TKey, TValue>> observer)
+    {
+        _valuesByKey.IsChangeCollectionEnabled = true;
+        
+        return ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<Unit>()
+                : _notificationsResumed
+                    .Take(1))
+            .Select(_ => _changeStream
+                .Finally(_onChangeStreamFinalized)
+                .Prepend(KeyedChangeSet.BulkAddition(_valuesByKey)))
+            .Switch()
+            .Subscribe(observer);
+    }
+
+    /// <inheritdoc/>
+    public NotificationSuspension SuspendNotifications()
+    {
+        ++_notificationSuspensionCount;
+        return new(this);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(
+                                        TKey    key,
+            [MaybeNullWhen(false)]  out TValue  value)
+        => _valuesByKey.TryGetValue(key, out value);
+
+    bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
+        => false;
+
+    ICollection<TKey> IDictionary<TKey, TValue>.Keys
+        => _valuesByKey.Keys;
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+        => _valuesByKey.Keys;
+
+    ICollection<TValue> IDictionary<TKey, TValue>.Values
+        => _valuesByKey.Values;
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+        => _valuesByKey.Values;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        => _valuesByKey.GetEnumerator();
+
+    IDisposable ISubjectDictionary<TKey, TValue>.SuspendNotifications()
+        => SuspendNotifications();
+
+    private void OnNotificationSuspensionDisposed()
+    {
+        --_notificationSuspensionCount;
+        if (_notificationSuspensionCount is 0)
+        {
+            PublishPendingNotifications();
+
+            _notificationsResumed.OnNext(Unit.Default);
+        }
+    }
+
+    private void PublishPendingNotifications()
+    {
+        if ((_notificationSuspensionCount is not 0) || !_valuesByKey.IsDirty)
+            return;
+
+        _collectionChanged.OnNext(Unit.Default);
+
+        _changeStream.OnNext(_valuesByKey.CaptureChangesAndClean());
+    }
+
+    /// <summary>
+    /// A value that controls suspension of notifications, for a <see cref="SubjectDictionary{TKey, TValue}"/>. Will trigger notifications to be resumed, when disposed.
+    /// </summary>
+    public struct NotificationSuspension
+        : IDisposable
+    {
+        private SubjectDictionary<TKey, TValue>? _owner;
+
+        internal NotificationSuspension(SubjectDictionary<TKey, TValue> owner)
+            => _owner = owner;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_owner is not null)
+            {
+                _owner.OnNotificationSuspensionDisposed();
+                _owner = null;
+            }
+        }
+    }
+}

--- a/src/DynamicDataVNext/Sorted/ChangeTrackingList.cs
+++ b/src/DynamicDataVNext/Sorted/ChangeTrackingList.cs
@@ -1,0 +1,416 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DynamicDataVNext;
+
+public sealed class ChangeTrackingList<T>
+    : IExtendedList<T>,
+        IReadOnlyList<T>
+{
+    private readonly SortedChangeSet.Builder<T> _changeCollector;
+    private readonly IEqualityComparer<T>       _comparer;
+    private readonly List<T>                    _items;
+
+    private bool _isChangeCollectionEnabled;
+    private bool _isDirty;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="ChangeTrackingList{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="comparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public ChangeTrackingList(
+        int?                    capacity = null,
+        IEqualityComparer<T>?   comparer = null)
+    {
+        _comparer = comparer ?? EqualityComparer<T>.Default;
+
+        _items = (capacity is int givenCapacity)
+            ? new(capacity: givenCapacity)
+            : new();
+
+        _changeCollector = new();
+        _isChangeCollectionEnabled = true;
+    }
+
+    /// <inheritdoc/>
+    public T this[int index]
+    {
+        get => _items[index];
+        set
+        {
+            if (_items.Count > index)
+            {
+                var oldValue = _items[index];
+
+                if (_comparer.Equals(oldValue, value))
+                    return;
+
+                _items[index] = value;
+
+                if (_isChangeCollectionEnabled)
+                    _changeCollector.AddChange(SortedChange.Replacement(
+                        index:      index,
+                        oldItem:    oldValue,
+                        newItem:    value));
+            }
+            else
+            {
+                _items.Add(value);
+
+                if (_isChangeCollectionEnabled)
+                    _changeCollector.AddChange(SortedChange.Insertion(
+                        index:  index,
+                        item:   value));
+            }
+
+            _isDirty = true;
+        }
+    }
+
+    /// <summary>
+    /// The comparer to be used for detecting value changes, within the collection.
+    /// </summary>
+    public IEqualityComparer<T> Comparer
+        => _comparer;
+
+    /// <inheritdoc/>
+    public int Count
+        => _items.Count;
+
+    /// <summary>
+    /// A flag indicating whether the collection should actually collect changes, to be retrieved by calls to <see cref="CaptureChangesAndClean"/>.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note that any changes previously collected, but not captured, when this property is set to <see langword="false"/> will be discarded. Otherwise, it would be possible for <see cref="CaptureChangesAndClean"/> to generate a corrupt changes, when next called, after setting this property back to <see langword="true"/>.
+    /// </remarks>
+    public bool IsChangeCollectionEnabled
+    { 
+        get => _isChangeCollectionEnabled;
+        set
+        {
+            if ((value is false) && (_changeCollector.Count is not 0))
+                _changeCollector.Clear();
+
+            _isChangeCollectionEnabled = value;
+        }
+    }
+
+    /// <summary>
+    /// A flag indicating whether changes have been made to the collection since its creation, or since the last call to `<see cref="CaptureChangesAndClean"/>.
+    /// </summary>
+    public bool IsDirty
+        => _isDirty;
+
+    /// <inheritdoc/>
+    public void Add(T item)
+    {
+        _items.Add(item);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.AddChange(SortedChange.Insertion(
+                index:  _items.Count - 1,
+                item:   item));
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(IEnumerable<T> items)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            if (items.TryGetNonEnumeratedCount(out var itemCount))
+            {
+                _items.EnsureCapacity(_items.Count + itemCount);
+
+                _changeCollector.EnsureCapacity(itemCount);
+            }
+
+            foreach (var item in items)
+            {
+                _items.Add(item);
+
+                _changeCollector.AddChange(SortedChange.Insertion(
+                    index:  _items.Count - 1,
+                    item:   item));
+
+                _isDirty = true;
+            }
+        }
+        else
+        {
+            var oldCount = _items.Count;
+
+            _items.AddRange(items);
+
+            _isDirty = oldCount != _items.Count;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(ReadOnlySpan<T> items)
+    {
+        if (items.Length is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _items.EnsureCapacity(_items.Count + items.Length);
+
+            _changeCollector.EnsureCapacity(items.Length);
+
+            foreach (var item in items)
+            {
+                _items.Add(item);
+
+                _changeCollector.AddChange(SortedChange.Insertion(
+                    index:  _items.Count - 1,
+                    item:   item));
+            }
+        }
+        else
+        {
+            _items.AddRange(items);
+        }
+
+        _isDirty = true;
+    }
+
+    /// <summary>
+    /// Captures any previously-collected changes made to the collection, and resets the collection to a "clean" state (I.E. sets <see cref="IsDirty"/> to <see langword="false"/>).
+    /// </summary>
+    /// <returns>A <see cref="SortedChangeSet{T}"/> containing all changes made to the collection since its construction, the last call to <see cref="CaptureChangesAndClean"/>, or since <see cref="IsChangeCollectionEnabled"/> was last changed to <see langword="true"/>.</returns>
+    /// <remarks>
+    /// Note that this method will always return an empty changeset, when <see cref="IsChangeCollectionEnabled"/> is <see langword="false"/>.
+    /// </remarks>
+    public SortedChangeSet<T> CaptureChangesAndClean()
+    {
+        _isDirty = false;
+        return _changeCollector.BuildAndClear();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (_items.Count is 0)
+            return;
+
+        _changeCollector.EnsureCapacity(_items.Count);
+
+        if (_isChangeCollectionEnabled)
+        {
+            for (var index = _items.Count - 1; index >= 0; --index)
+                _changeCollector.AddChange(SortedChange.Removal(
+                    index:  index,
+                    item:   _items[index]));
+
+            _changeCollector.OnSourceCleared();
+        }
+
+        _items.Clear();
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+        => _items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(
+            T[] array,
+            int arrayIndex)
+        => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc cref="List{T}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _items.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public List<T>.Enumerator GetEnumerator()
+        => _items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(T item)
+        => _items.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(
+            int index,
+            T   item)
+        => _items.Insert(index, item);
+
+    /// <inheritdoc/>
+    public void InsertRange(
+        int             index,
+        IEnumerable<T>  items)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            if (items.TryGetNonEnumeratedCount(out var itemCount))
+            {
+                _items.EnsureCapacity(_items.Count + itemCount);
+
+                _changeCollector.EnsureCapacity(itemCount);
+            }
+
+            var insertionIndex = index;
+            foreach (var item in items)
+            {
+                _items.Insert(
+                    index:  insertionIndex,
+                    item:   item);
+
+                _changeCollector.AddChange(SortedChange.Insertion(
+                    index:  insertionIndex,
+                    item:   item));
+
+                ++insertionIndex;
+                _isDirty = true;
+            }
+        }
+        else
+        {
+            var oldCount = _items.Count;
+
+            _items.InsertRange(index, items);
+
+            _isDirty = oldCount != _items.Count;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void InsertRange(
+        int             index,
+        ReadOnlySpan<T> items)
+    {
+        if (items.Length is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            _items.EnsureCapacity(_items.Count + items.Length);
+
+            _changeCollector.EnsureCapacity(items.Length);
+
+            var insertionIndex = index;
+            foreach (var item in items)
+            {
+                _items.Insert(
+                    index:  insertionIndex,
+                    item:   item);
+
+                _changeCollector.AddChange(SortedChange.Insertion(
+                    index:  insertionIndex,
+                    item:   item));
+
+                ++insertionIndex;
+            }
+        }
+        else
+        {
+            _items.InsertRange(index, items);
+        }
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex)
+            return;
+
+        var item = _items[oldIndex];
+
+        _items.RemoveAt(oldIndex);
+        _items.Insert(
+            index:  newIndex,
+            item:   item);
+
+        if (_isChangeCollectionEnabled)
+            _changeCollector.AddChange(SortedChange.Movement(oldIndex, newIndex, item));
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            var index = _items.IndexOf(item);
+            if (index < 0)
+                return false;
+
+            _items.RemoveAt(index);
+
+            _isDirty = true;
+            return true;
+        }
+        else
+        {
+            var result = _items.Remove(item);
+
+            _isDirty |= result;
+
+            return result;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        if (_isChangeCollectionEnabled)
+        {
+            var item = _items[index];
+
+            _changeCollector.AddChange(SortedChange.Removal(index, item));
+        }
+
+        _items.RemoveAt(index);
+
+        _isDirty = true;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(
+        int index,
+        int count)
+    {
+        if (count is 0)
+            return;
+
+        if (_isChangeCollectionEnabled)
+        {
+            for (var i = index + count - 1; i >= index; --i)
+            {
+                var item = _items[i];
+
+                _changeCollector.AddChange(SortedChange.Removal(
+                    index:  i,
+                    item:   item));
+            }
+
+            if (_items.Count == count)
+                _changeCollector.OnSourceCleared();
+        }
+        
+        _items.RemoveRange(index, count);
+
+        _isDirty = true;
+    }
+
+    bool ICollection<T>.IsReadOnly
+        => false;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        => _items.GetEnumerator();
+}

--- a/src/DynamicDataVNext/Sorted/IExtendedList.cs
+++ b/src/DynamicDataVNext/Sorted/IExtendedList.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// Describes an extended version of <see cref="IList{T}"/>, supporting range and movement operations.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public interface IExtendedList<T>
+    : IList<T>
+{
+    /// <summary>
+    /// Adds a range of items to the end of the list.
+    /// </summary>
+    /// <param name="items">The items to be added.</param>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void AddRange(IEnumerable<T> items);
+
+    /// <summary>
+    /// Adds a range of items to the end of the list.
+    /// </summary>
+    /// <param name="items">The items to be added.</param>
+    void AddRange(ReadOnlySpan<T> items);
+
+    /// <summary>
+    /// Inserts a range of items into the list.
+    /// </summary>
+    /// <param name="index">The index at which the first item in the range should be inserted.</param>
+    /// <param name="items">The items to be inserted.</param>
+    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="index"/> does not represent a valid index of an item in the list, or the next available index of the list.</exception>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void InsertRange(
+        int             index,
+        IEnumerable<T>  items);
+
+    /// <summary>
+    /// Inserts a range of items into the list.
+    /// </summary>
+    /// <param name="index">The index at which the first item in the range should be inserted.</param>
+    /// <param name="items">The items to be inserted.</param>
+    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="index"/> does not represent a valid index of an item in the list, or the next available index of the list.</exception>
+    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
+    void InsertRange(
+        int             index,
+        ReadOnlySpan<T> items);
+
+    /// <summary>
+    /// Moves an item within the list.
+    /// </summary>
+    /// <param name="oldIndex">The index of the item to be moved, before the operation.</param>
+    /// <param name="newIndex">The desired index of the item to be moved, after the operation.</param>
+    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="oldIndex"/> or <paramref name="newIndex"/> does not represent a valid index of an item in the list.</exception>
+    void Move(
+        int oldIndex,
+        int newIndex);
+
+    /// <summary>
+    /// Removes a range of consecutive items from the list.
+    /// </summary>
+    /// <param name="index">The index of the first item to be removed.</param>
+    /// <param name="count">The number of items to be removed.</param>
+    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="index"/> does not represent a valid index of an item within the list.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="count"/> and <paramref name="index"/> define a range that extends beyond the end of the list.</exception>
+    void RemoveRange(
+        int index,
+        int count);
+}

--- a/src/DynamicDataVNext/Sorted/IObservableList.cs
+++ b/src/DynamicDataVNext/Sorted/IObservableList.cs
@@ -17,7 +17,4 @@ public interface IObservableList<T>
 
     /// <inheritdoc cref="ISubjectList{T}.ObserveValue(int)"/>
     IObservable<T> ObserveValue(int index);
-
-    /// <inheritdoc cref="ISubjectList{T}.SuspendNotifications"/>
-    IDisposable SuspendNotifications();
 }

--- a/src/DynamicDataVNext/Sorted/ISubjectList.cs
+++ b/src/DynamicDataVNext/Sorted/ISubjectList.cs
@@ -9,7 +9,7 @@ namespace DynamicDataVNext;
 /// </summary>
 /// <typeparam name="T">The type of the items in the collection.</typeparam>
 public interface ISubjectList<T>
-    : IList<T>,
+    : IExtendedList<T>,
         IObservable<SortedChangeSet<T>>
 {
     /// <summary>
@@ -18,53 +18,15 @@ public interface ISubjectList<T>
     IObservable<Unit> CollectionChanged { get; }
 
     /// <summary>
-    /// Adds a range of items to the end of the list.
-    /// </summary>
-    /// <param name="items">The items to be added.</param>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
-    void AddRange(IEnumerable<T> items);
-
-    /// <summary>
-    /// Inserts a range of items into the list.
-    /// </summary>
-    /// <param name="index">The index at which the first item in the range should be inserted.</param>
-    /// <param name="items">The items to be inserted.</param>
-    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="index"/> does not represent a valid index of an item in the list, or the next available index of the list.</exception>
-    /// <exception cref="ArgumentNullException">Throws for <paramref name="items"/>.</exception>
-    void InsertRange(
-        int             index,
-        IEnumerable<T>  items);
-
-    /// <summary>
-    /// Moves an item within the list.
-    /// </summary>
-    /// <param name="oldIndex">The index of the item to be moved, before the operation.</param>
-    /// <param name="newIndex">The desired index of the item to be moved, after the operation.</param>
-    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="oldIndex"/> or <paramref name="newIndex"/> does not represent a valid index of an item in the list.</exception>
-    void Move(
-        int oldIndex,
-        int newIndex);
-
-    /// <summary>
     /// Allows subscribers to observe the item in the collection, at a particular index, as it changes.
     /// </summary>
     /// <param name="index">The index whose item is to be observed.</param>
     /// <returns>A stream which will publish the latest item, for the given index, within the collection.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Throws if <paramref name="index"/> is negative.</exception>
     /// <remarks>
     /// The returned stream will always immediately publish the current item for the given index, upon subscription, and will complete if the given index is removed. If the index is not present within the collection upon subscription, the stream will complete immediately.
     /// </remarks>
     IObservable<T> ObserveValue(int index);
-
-    /// <summary>
-    /// Removes a range of consecutive items from the list.
-    /// </summary>
-    /// <param name="index">The index of the first item to be removed.</param>
-    /// <param name="count">The number of items to be removed.</param>
-    /// <exception cref="IndexOutOfRangeException">Throws when <paramref name="index"/> does not represent a valid index of an item within the list.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="count"/> and <paramref name="index"/> define a range that extends beyond the end of the list.</exception>
-    void RemoveRange(
-        int index,
-        int count);
 
     /// <summary>
     /// Temporarily suspends the publication of notifications by the collection, until the returned object is disposed, at which point all mutations made during the suspension will (if any) will be published as one notification.

--- a/src/DynamicDataVNext/Sorted/SortedChangeSet.cs
+++ b/src/DynamicDataVNext/Sorted/SortedChangeSet.cs
@@ -70,55 +70,6 @@ public static partial class SortedChangeSet
         };
 
     /// <summary>
-    /// Creates a new <see cref="SortedChangeSet{T}"/> representing the insertion of a range of items.
-    /// </summary>
-    /// <typeparam name="T">The type of items being inserted.</typeparam>
-    /// <param name="index">The index at which the items are being inserted.</param>
-    /// <param name="items">The items being inserted.</param>
-    /// <returns>A <see cref="SortedChangeSet{T}"/> describing the insertion of the given items.</returns>
-    public static SortedChangeSet<T> Insertion<T>(
-        int             index,
-        IEnumerable<T>  items)
-    {
-        if (!items.TryGetNonEnumeratedCount(out var itemsCount))
-            itemsCount = 0;
-
-        var changes = ImmutableArray.CreateBuilder<SortedChange<T>>(initialCapacity: itemsCount);
-
-        var insertionIndex = index;
-        foreach(var item in items)
-            changes.Add(SortedChange.Insertion(
-                index:  insertionIndex++,
-                item:   item));
-
-        return new()
-        {
-            Changes = changes.MoveToOrCreateImmutable(),
-            Type    = ChangeSetType.Update
-        };
-    }
-
-    /// <inheritdoc cref="Insertion{T}(int, IEnumerable{T})"/>
-    public static SortedChangeSet<T> Insertion<T>(
-        int             index,
-        ReadOnlySpan<T> items)
-    {
-        var changes = ImmutableArray.CreateBuilder<SortedChange<T>>(initialCapacity: items.Length);
-
-        var insertionIndex = index;
-        foreach(var item in items)
-            changes.Add(SortedChange.Insertion(
-                index:  insertionIndex++,
-                item:   item));
-
-        return new()
-        {
-            Changes = changes.MoveToImmutable(),
-            Type    = ChangeSetType.Update
-        };
-    }
-
-    /// <summary>
     /// Creates a new <see cref="SortedChangeSet{T}"/> representing the movement of a single item.
     /// </summary>
     /// <typeparam name="T">The type of item being moved.</typeparam>
@@ -140,22 +91,53 @@ public static partial class SortedChangeSet
         };
 
     /// <summary>
-    /// Creates a new <see cref="SortedChangeSet{T}"/> representing the removal of a single item.
+    /// Creates a new <see cref="SortedChangeSet{T}"/> representing the insertion of a range of items.
     /// </summary>
-    /// <typeparam name="T">The type of item being removed.</typeparam>
-    /// <param name="index">The index of the item being removed.</param>
-    /// <param name="item">The item being removed.</param>
-    /// <returns>A <see cref="SortedChangeSet{T}"/> describing the removal of the given item.</returns>
-    public static SortedChangeSet<T> Removal<T>(
-            int index,
-            T   item)
-        => new()
+    /// <typeparam name="T">The type of items being inserted.</typeparam>
+    /// <param name="index">The index at which the items are being inserted.</param>
+    /// <param name="items">The items being inserted.</param>
+    /// <returns>A <see cref="SortedChangeSet{T}"/> describing the insertion of the given items.</returns>
+    public static SortedChangeSet<T> RangeInsertion<T>(
+        int             index,
+        IEnumerable<T>  items)
+    {
+        if (!items.TryGetNonEnumeratedCount(out var itemsCount))
+            itemsCount = 0;
+
+        var changes = ImmutableArray.CreateBuilder<SortedChange<T>>(initialCapacity: itemsCount);
+
+        var insertionIndex = index;
+        foreach(var item in items)
+            changes.Add(SortedChange.Insertion(
+                index:  insertionIndex++,
+                item:   item));
+
+        return new()
         {
-            Changes = ImmutableArray.Create(SortedChange.Removal(
-                index:  index,
-                item:   item)),
+            Changes = changes.MoveToOrCreateImmutable(),
             Type    = ChangeSetType.Update
         };
+    }
+
+    /// <inheritdoc cref="RangeInsertion{T}(int, IEnumerable{T})"/>
+    public static SortedChangeSet<T> RangeInsertion<T>(
+        int             index,
+        ReadOnlySpan<T> items)
+    {
+        var changes = ImmutableArray.CreateBuilder<SortedChange<T>>(initialCapacity: items.Length);
+
+        var insertionIndex = index;
+        foreach(var item in items)
+            changes.Add(SortedChange.Insertion(
+                index:  insertionIndex++,
+                item:   item));
+
+        return new()
+        {
+            Changes = changes.MoveToImmutable(),
+            Type    = ChangeSetType.Update
+        };
+    }
 
     /// <summary>
     /// Creates a new <see cref="SortedChangeSet{T}"/> representing the removal of a range of items.
@@ -165,7 +147,7 @@ public static partial class SortedChangeSet
     /// <param name="index">The index at which the sequence of removed items begins.</param>
     /// <param name="items">The items being removed.</param>
     /// <returns>A <see cref="SortedChangeSet{T}"/> describing the removal of the given items.</returns>
-    public static SortedChangeSet<T> Removal<T, TItems>(
+    public static SortedChangeSet<T> RangeRemoval<T, TItems>(
         int                 index,
         IReadOnlyList<T>    items)
     {
@@ -184,8 +166,8 @@ public static partial class SortedChangeSet
         };
     }
 
-    /// <inheritdoc cref="Removal{T, TItems}(int, IReadOnlyList{T})"/>
-    public static SortedChangeSet<T> Removal<T, TItems>(
+    /// <inheritdoc cref="RangeRemoval{T, TItems}(int, IReadOnlyList{T})"/>
+    public static SortedChangeSet<T> RangeRemoval<T, TItems>(
         int             index,
         ReadOnlySpan<T> items)
     {
@@ -203,6 +185,24 @@ public static partial class SortedChangeSet
             Type    = ChangeSetType.Update
         };
     }
+
+    /// <summary>
+    /// Creates a new <see cref="SortedChangeSet{T}"/> representing the removal of a single item.
+    /// </summary>
+    /// <typeparam name="T">The type of item being removed.</typeparam>
+    /// <param name="index">The index of the item being removed.</param>
+    /// <param name="item">The item being removed.</param>
+    /// <returns>A <see cref="SortedChangeSet{T}"/> describing the removal of the given item.</returns>
+    public static SortedChangeSet<T> Removal<T>(
+            int index,
+            T   item)
+        => new()
+        {
+            Changes = ImmutableArray.Create(SortedChange.Removal(
+                index:  index,
+                item:   item)),
+            Type    = ChangeSetType.Update
+        };
 
     /// <summary>
     /// Creates a new <see cref="SortedChangeSet{T}"/> representing the replacement of a single item.

--- a/src/DynamicDataVNext/Sorted/SortedMovement.cs
+++ b/src/DynamicDataVNext/Sorted/SortedMovement.cs
@@ -20,4 +20,13 @@ public readonly record struct SortedMovement<T>
     /// The index of the item within the collection, before being moved.
     /// </summary>
     public required int OldIndex { get; init; }
+
+    /// <summary>
+    /// Checks whether a given index is affected by this movement change.
+    /// </summary>
+    /// <param name="index">The index to check.</param>
+    /// <returns><see langword="true"/> if the given index falls within the range of moved items represented by this change; <see langword="false"/> otherwise.</returns>
+    public bool IsIndexAffected(int index)
+        =>      ((index >= NewIndex) && (index <= OldIndex))
+            ||  ((index >= OldIndex) && (index <= NewIndex));
 }

--- a/src/DynamicDataVNext/Sorted/SubjectList.cs
+++ b/src/DynamicDataVNext/Sorted/SubjectList.cs
@@ -1,0 +1,327 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace DynamicDataVNext;
+
+/// <summary>
+/// The basic implementation of <see cref="ISubjectList{T}"/>, providing simple collection and change notification functionality, with no concurrency or thread-safety.
+/// </summary>
+/// <typeparam name="T">The type of the items in the collection.</typeparam>
+public sealed class SubjectList<T>
+        : ISubjectList<T>,
+            IObservableList<T>,
+            IDisposable
+    where T : notnull
+{
+    private readonly Subject<SortedChangeSet<T>>    _changeStream;
+    private readonly Subject<Unit>                  _collectionChanged;
+    private readonly Subject<Unit>                  _notificationsResumed;
+    private readonly Action                         _onChangeStreamFinalized;
+    private readonly ChangeTrackingList<T>          _items;
+
+    private int _notificationSuspensionCount;
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SubjectSet{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial number of items that the collection should be able to contain, before needing to allocation additional memory.</param>
+    /// <param name="comparer">The comparer to be used for detecting item changes, within the collection, or <see langword="null"/> if <see cref="EqualityComparer{T}.Default"/> should be used.</param>
+    public SubjectList(
+        int?                    capacity = null,
+        IEqualityComparer<T>?   comparer = null)
+    {
+        _collectionChanged      = new();
+        _changeStream           = new();
+        _notificationsResumed   = new();
+        _items                  = new(
+            capacity:   capacity,
+            comparer:   comparer);
+
+        _onChangeStreamFinalized = () => _items.IsChangeCollectionEnabled = _changeStream.HasObservers;
+    }
+
+    /// <inheritdoc/>
+    public T this[int index]
+    {
+        get => _items[index];
+        set
+        {
+            _items[index] = value;
+
+            PublishPendingNotifications();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IObservable<Unit> CollectionChanged
+        => _collectionChanged;
+
+    /// <inheritdoc/>
+    public int Count
+        => _items.Count;
+
+    /// <inheritdoc/>
+    public void Add(T item)
+    {
+        _items.Add(item);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(IEnumerable<T> items)
+    {
+        _items.AddRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(ReadOnlySpan<T> items)
+    {
+        _items.AddRange(items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        _items.Clear();
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+        => _items.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+        => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _changeStream           .OnCompleted();
+        _collectionChanged      .OnCompleted();
+        _notificationsResumed   .OnCompleted();
+
+        _changeStream           .Dispose();
+        _collectionChanged      .Dispose();
+        _notificationsResumed   .Dispose();
+    }
+
+    /// <inheritdoc cref="ChangeTrackingList{T}.EnsureCapacity(int)"/>
+    public void EnsureCapacity(int capacity)
+        => _items.EnsureCapacity(capacity);
+
+    /// <inheritdoc/>
+    public List<T>.Enumerator GetEnumerator()
+        => _items.GetEnumerator();
+
+    /// <inheritdoc/>
+    public int IndexOf(T item)
+        => _items.IndexOf(item);
+
+    /// <inheritdoc/>
+    public void Insert(int index, T item)
+    {
+        _items.Insert(index, item);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void InsertRange(int index, IEnumerable<T> items)
+    {
+        _items.InsertRange(index, items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void InsertRange(int index, ReadOnlySpan<T> items)
+    {
+        _items.InsertRange(index, items);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void Move(int oldIndex, int newIndex)
+    {
+        _items.Move(oldIndex, newIndex);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public IObservable<T> ObserveValue(int index)
+        => ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<T>()
+                : Observable.Never<T>()
+                    .TakeUntil(_notificationsResumed))
+            .Concat(Observable.Create<T>(observer =>
+            {
+                _items.IsChangeCollectionEnabled = true;
+
+                if (index >= _items.Count)
+                {
+                    observer.OnCompleted();
+                    return Disposable.Empty;
+                }
+
+                var oldItem = _items[index];
+                observer.OnNext(oldItem);
+                return _changeStream
+                    .Finally(_onChangeStreamFinalized)
+                    .SubscribeSafe(Observer.Create<SortedChangeSet<T>>(
+                        onNext:         changeSet =>
+                        {
+                            switch (changeSet.Type)
+                            {
+                                case ChangeSetType.Clear:
+                                    observer.OnCompleted();
+                                    break;
+
+                                case ChangeSetType.Reset:
+                                    if (index < _items.Count)
+                                    {
+                                        oldItem = _items[index];
+                                        observer.OnNext(oldItem);
+                                    }
+                                    else
+                                        observer.OnCompleted();
+                                    break;
+
+                                default:
+                                    if (index < _items.Count)
+                                    {
+                                        var newItem = _items[index];
+                                        if (_items.Comparer.Equals(oldItem, newItem))
+                                            break;
+                                        oldItem = newItem;
+                                        observer.OnNext(newItem);
+                                    }
+                                    else
+                                        observer.OnCompleted();
+                                    break;
+                            }
+                        },
+                        onError:        observer.OnError,
+                        onCompleted:    observer.OnCompleted));
+            }));
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        var result = _items.Remove(item);
+
+        PublishPendingNotifications();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        _items.RemoveAt(index);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public void RemoveRange(int index, int count)
+    {
+        _items.RemoveRange(index, count);
+
+        PublishPendingNotifications();
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<SortedChangeSet<T>> observer)
+    {
+        _items.IsChangeCollectionEnabled = true;
+        
+        return ((_notificationSuspensionCount is 0)
+                ? Observable.Empty<Unit>()
+                : _notificationsResumed
+                    .Take(1))
+            .Select(_ => _changeStream
+                .Finally(_onChangeStreamFinalized)
+                .Prepend(SortedChangeSet.RangeInsertion(
+                    index:  0,
+                    items:  _items)))
+            .Switch()
+            .Subscribe(observer);
+    }
+
+    /// <inheritdoc/>
+    public NotificationSuspension SuspendNotifications()
+    {
+        ++_notificationSuspensionCount;
+        return new(this);
+    }
+
+    bool ICollection<T>.IsReadOnly
+        => false;
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        => _items.GetEnumerator();
+
+    IDisposable ISubjectList<T>.SuspendNotifications()
+        => SuspendNotifications();
+
+    private void OnNotificationSuspensionDisposed()
+    {
+        --_notificationSuspensionCount;
+        if (_notificationSuspensionCount is 0)
+        {
+            PublishPendingNotifications();
+
+            _notificationsResumed.OnNext(Unit.Default);
+        }
+    }
+
+    private void PublishPendingNotifications()
+    {
+        if ((_notificationSuspensionCount is not 0) || !_items.IsDirty)
+            return;
+
+        _collectionChanged.OnNext(Unit.Default);
+
+        _changeStream.OnNext(_items.CaptureChangesAndClean());
+    }
+
+    /// <summary>
+    /// A value that controls suspension of notifications, for a <see cref="SubjectList{T}"/>. Will trigger notifications to be resumed, when disposed.
+    /// </summary>
+    public struct NotificationSuspension
+        : IDisposable
+    {
+        private SubjectList<T>? _owner;
+
+        internal NotificationSuspension(SubjectList<T> owner)
+            => _owner = owner;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_owner is not null)
+            {
+                _owner.OnNotificationSuspensionDisposed();
+                _owner = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Main points:

* Defined classes for 4 collection types: `Set`, `Cache`, `Dictionary`, and `List`, matching the previously-defined interfaces.
* Defined `ChangeTrackingXXX` classes for each collection type. These classes mimic the `ChangeAwareXXX` classes from DD today, and form the core of each `SubjectXXX` class, as well as a great basis for implementing operators, going forward.
* Defined `SubjectXXX` classes for each collection type. These classes mimic the `SourceXXX` classes from DD today, and are the main public API for building change streams.
* The `SubjectXXX` can be extended or decorated in the future to add different levels of concurrency and thread-safety. This should allow consumers who don't need thread-safety to get more performance out of the library, and those who do need it to opt into it.

There were a few things I cleaned up across the collection interfaces, including the following:

* A bunch of spots where collections were defined as `IObservable<>` of changes, rather than change sets.
* Some naming for range methods, to avoid some ambiguous resolution issues I had.
* After some discussion in Slack, re-defined Dictionary and Cache to support `AddOrReplaceRange()` instead of `AddRange()`. This eliminates the possibility for corrupt collection states to occur, in the event of key mismatches by the consumer, and mimics how `SourceCache<>` behaves in DD today.
* Split out all collection mutation methods not related to change publishing into `IExtendedXXX<>` interfaces, to allow for `ChangeTrackingXXX` collections to be defined.

